### PR TITLE
Integrate sidebar organizer into sidebar

### DIFF
--- a/components/layouts/sidebarOrganizer/CategoryHeader.tsx
+++ b/components/layouts/sidebarOrganizer/CategoryHeader.tsx
@@ -65,9 +65,10 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
   onKeyDown,
 }) => {
   const showActions = !isEditing;
+  const errorId = editingError ? `rename-${categoryId}-error` : undefined;
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-1">
       <div
         className="group mb-2 flex items-center justify-between rounded-md px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary/70"
         draggable={!isEditing}
@@ -87,7 +88,7 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
       >
         <div className="flex flex-1 items-center gap-2 overflow-hidden">
           <div
-            className={`flex items-center gap-1 overflow-hidden transition-[width,opacity] duration-200 ease-out ${
+            className={`flex flex-shrink-0 items-center gap-1 overflow-hidden transition-[width,opacity] duration-200 ease-out ${
               showActions
                 ? 'w-0 opacity-0 group-hover:w-[3.5rem] group-hover:opacity-100 group-focus-within:w-[3.5rem] group-focus-within:opacity-100'
                 : 'w-0 opacity-0'
@@ -115,7 +116,27 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
               </>
             ) : null}
           </div>
-          <span className="truncate">{name}</span>
+          {isEditing ? (
+            <>
+              <label className="sr-only" htmlFor={`rename-${categoryId}`}>
+                {labels.renameCategory}
+              </label>
+              <input
+                id={`rename-${categoryId}`}
+                className="min-w-0 flex-1 rounded-md border border-border-color bg-surface px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                value={editingValue}
+                onChange={event => onRenameChange(categoryId, event.target.value)}
+                onKeyDown={onRenameKeyDown}
+                onBlur={onRenameBlur}
+                onFocus={event => event.currentTarget.select()}
+                aria-invalid={editingError ? true : undefined}
+                aria-describedby={errorId}
+                autoFocus
+              />
+            </>
+          ) : (
+            <span className="truncate">{name}</span>
+          )}
         </div>
         <button
           type="button"
@@ -126,23 +147,10 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
           {isCollapsed ? '▸' : '▾'}
         </button>
       </div>
-      {isEditing ? (
-        <div className="px-2">
-          <label className="sr-only" htmlFor={`rename-${categoryId}`}>
-            {labels.renameCategory}
-          </label>
-          <input
-            id={`rename-${categoryId}`}
-            className="w-full rounded-md border border-border-color bg-surface px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            value={editingValue}
-            onChange={event => onRenameChange(categoryId, event.target.value)}
-            onKeyDown={onRenameKeyDown}
-            onBlur={onRenameBlur}
-            onFocus={event => event.currentTarget.select()}
-            autoFocus
-          />
-          {editingError ? <p className="mt-1 text-xs text-red-500">{editingError}</p> : null}
-        </div>
+      {editingError ? (
+        <p id={errorId} className="px-2 text-xs text-red-500">
+          {editingError}
+        </p>
       ) : null}
     </div>
   );

--- a/components/layouts/sidebarOrganizer/CategoryHeader.tsx
+++ b/components/layouts/sidebarOrganizer/CategoryHeader.tsx
@@ -3,6 +3,8 @@
  */
 
 import React from 'react';
+import HandymanIcon from '@mui/icons-material/Handyman';
+import HighlightOffIcon from '@mui/icons-material/HighlightOff';
 import type { SidebarOrganizerLabels } from './types';
 
 interface CategoryHeaderProps {
@@ -12,6 +14,10 @@ interface CategoryHeaderProps {
   name: string;
   /** Indicates that this category is currently dragged. */
   isDragging: boolean;
+  /** Highlights the header when another category is targeting it. */
+  isCategoryDropTarget: boolean;
+  /** Highlights the header when a feature intends to drop into the category. */
+  isFeatureDropTarget: boolean;
   /** Accessibility labels used for tooltips. */
   labels: SidebarOrganizerLabels;
   /** When true the features list is collapsed. */
@@ -40,6 +46,12 @@ interface CategoryHeaderProps {
   onDragEnd: () => void;
   /** Keyboard handler used for accessible drag toggling. */
   onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+  /** Handles drag over events to support dropping features or categories on the header. */
+  onHeaderDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  /** Clears drop target state when the pointer leaves the header area. */
+  onHeaderDragLeave: (event: React.DragEvent<HTMLDivElement>) => void;
+  /** Processes drop events for categories and features. */
+  onHeaderDrop: (event: React.DragEvent<HTMLDivElement>) => void;
 }
 
 /**
@@ -49,6 +61,8 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
   categoryId,
   name,
   isDragging,
+  isCategoryDropTarget,
+  isFeatureDropTarget,
   labels,
   isCollapsed,
   isEditing,
@@ -63,14 +77,24 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
   onDragStart,
   onDragEnd,
   onKeyDown,
+  onHeaderDragOver,
+  onHeaderDragLeave,
+  onHeaderDrop,
 }) => {
   const showActions = !isEditing;
   const errorId = editingError ? `rename-${categoryId}-error` : undefined;
+  const isDropTarget = isCategoryDropTarget || isFeatureDropTarget;
+  const containerClasses = [
+    'group mb-2 flex items-center justify-between rounded-md px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary/70 transition-colors',
+    isDropTarget ? 'bg-primary/10 ring-2 ring-primary/60' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
 
   return (
     <div className="space-y-1">
       <div
-        className="group mb-2 flex items-center justify-between rounded-md px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary/70"
+        className={containerClasses}
         draggable={!isEditing}
         onDragStart={event => {
           if (isEditing) {
@@ -81,9 +105,13 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
         }}
         onDragEnd={onDragEnd}
         onKeyDown={onKeyDown}
+        onDragOver={onHeaderDragOver}
+        onDragLeave={onHeaderDragLeave}
+        onDrop={onHeaderDrop}
         tabIndex={isEditing ? -1 : 0}
         role="button"
         aria-grabbed={isDragging}
+        aria-dropeffect={isDropTarget ? 'move' : undefined}
         data-category-id={categoryId}
       >
         <div className="flex flex-1 items-center gap-2 overflow-hidden">
@@ -103,7 +131,7 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
                   onClick={onBeginRename}
                   aria-label={labels.renameCategory}
                 >
-                  🔧
+                  <HandymanIcon fontSize="small" />
                 </button>
                 <button
                   type="button"
@@ -111,7 +139,7 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
                   onClick={onDelete}
                   aria-label={labels.deleteCategory}
                 >
-                  ✕
+                  <HighlightOffIcon fontSize="small" />
                 </button>
               </>
             ) : null}

--- a/components/layouts/sidebarOrganizer/CategoryHeader.tsx
+++ b/components/layouts/sidebarOrganizer/CategoryHeader.tsx
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Category header component exposing rename and delete controls.
+ */
+
+import React from 'react';
+import type { SidebarOrganizerLabels } from './types';
+
+interface CategoryHeaderProps {
+  /** Unique category identifier. */
+  categoryId: string;
+  /** Display label for the category. */
+  name: string;
+  /** Whether the sidebar is collapsed. */
+  collapsed: boolean;
+  /** Indicates that this category is currently dragged. */
+  isDragging: boolean;
+  /** Accessibility labels used for tooltips. */
+  labels: SidebarOrganizerLabels;
+  /** When true the features list is collapsed. */
+  isCollapsed: boolean;
+  /** Whether rename mode is active. */
+  isEditing: boolean;
+  /** Current rename input value. */
+  editingValue: string;
+  /** Inline validation message for rename. */
+  editingError: string | null;
+  /** Handler for toggling collapse. */
+  onToggleCollapse: () => void;
+  /** Handler for initiating rename. */
+  onBeginRename: () => void;
+  /** Handler for delete button. */
+  onDelete: () => void;
+  /** Input change handler for rename text. */
+  onRenameChange: (categoryId: string, value: string) => void;
+  /** Keydown handler for rename field. */
+  onRenameKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  /** Blur handler that commits rename. */
+  onRenameBlur: () => void;
+  /** Drag start handler for the category header. */
+  onDragStart: (event: React.DragEvent<HTMLDivElement>) => void;
+  /** Drag end handler. */
+  onDragEnd: () => void;
+  /** Keyboard handler used for accessible drag toggling. */
+  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * Renders the category title row along with rename/delete affordances.
+ */
+export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
+  categoryId,
+  name,
+  collapsed,
+  isDragging,
+  labels,
+  isCollapsed,
+  isEditing,
+  editingValue,
+  editingError,
+  onToggleCollapse,
+  onBeginRename,
+  onDelete,
+  onRenameChange,
+  onRenameKeyDown,
+  onRenameBlur,
+  onDragStart,
+  onDragEnd,
+  onKeyDown,
+}) => (
+  <div className="px-2">
+    <div
+      className={`group mb-2 flex items-center justify-between rounded-md px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary/70 ${
+        collapsed ? 'justify-center' : ''
+      }`}
+      draggable
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onKeyDown={onKeyDown}
+      tabIndex={0}
+      role="button"
+      aria-grabbed={isDragging}
+      data-category-id={categoryId}
+    >
+      <div className={`relative flex flex-1 items-center ${collapsed ? 'justify-center' : ''}`}>
+        <span className={collapsed ? 'sr-only' : 'truncate'}>{name}</span>
+        <div className="absolute left-0 flex gap-1 -translate-x-full opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100 group-focus-within:translate-x-0 group-focus-within:opacity-100">
+          <button
+            type="button"
+            className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={onBeginRename}
+            aria-label={labels.renameCategory}
+          >
+            🔧
+          </button>
+          <button
+            type="button"
+            className="flex h-6 w-6 items-center justify-center rounded-full bg-red-500 text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={onDelete}
+            aria-label={labels.deleteCategory}
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+      <button
+        type="button"
+        className="ml-2 text-xs text-text-secondary"
+        onClick={onToggleCollapse}
+        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${name}`}
+      >
+        {isCollapsed ? '▸' : '▾'}
+      </button>
+    </div>
+    {isEditing ? (
+      <div className="mb-3">
+        <label className="sr-only" htmlFor={`rename-${categoryId}`}>
+          {labels.renameCategory}
+        </label>
+        <input
+          id={`rename-${categoryId}`}
+          className="w-full rounded-md border border-border-color bg-surface px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          value={editingValue}
+          onChange={event => onRenameChange(categoryId, event.target.value)}
+          onKeyDown={onRenameKeyDown}
+          onBlur={onRenameBlur}
+          autoFocus
+        />
+        {editingError ? <p className="mt-1 text-xs text-red-500">{editingError}</p> : null}
+      </div>
+    ) : null}
+  </div>
+);

--- a/components/layouts/sidebarOrganizer/CategoryHeader.tsx
+++ b/components/layouts/sidebarOrganizer/CategoryHeader.tsx
@@ -10,8 +10,6 @@ interface CategoryHeaderProps {
   categoryId: string;
   /** Display label for the category. */
   name: string;
-  /** Whether the sidebar is collapsed. */
-  collapsed: boolean;
   /** Indicates that this category is currently dragged. */
   isDragging: boolean;
   /** Accessibility labels used for tooltips. */
@@ -50,7 +48,6 @@ interface CategoryHeaderProps {
 export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
   categoryId,
   name,
-  collapsed,
   isDragging,
   labels,
   isCollapsed,
@@ -66,67 +63,87 @@ export const CategoryHeader: React.FC<CategoryHeaderProps> = ({
   onDragStart,
   onDragEnd,
   onKeyDown,
-}) => (
-  <div className="px-2">
-    <div
-      className={`group mb-2 flex items-center justify-between rounded-md px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary/70 ${
-        collapsed ? 'justify-center' : ''
-      }`}
-      draggable
-      onDragStart={onDragStart}
-      onDragEnd={onDragEnd}
-      onKeyDown={onKeyDown}
-      tabIndex={0}
-      role="button"
-      aria-grabbed={isDragging}
-      data-category-id={categoryId}
-    >
-      <div className={`relative flex flex-1 items-center ${collapsed ? 'justify-center' : ''}`}>
-        <span className={collapsed ? 'sr-only' : 'truncate'}>{name}</span>
-        <div className="absolute left-0 flex gap-1 -translate-x-full opacity-0 transition-all duration-200 ease-out group-hover:translate-x-0 group-hover:opacity-100 group-focus-within:translate-x-0 group-focus-within:opacity-100">
-          <button
-            type="button"
-            className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={onBeginRename}
-            aria-label={labels.renameCategory}
-          >
-            🔧
-          </button>
-          <button
-            type="button"
-            className="flex h-6 w-6 items-center justify-center rounded-full bg-red-500 text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            onClick={onDelete}
-            aria-label={labels.deleteCategory}
-          >
-            ✕
-          </button>
-        </div>
-      </div>
-      <button
-        type="button"
-        className="ml-2 text-xs text-text-secondary"
-        onClick={onToggleCollapse}
-        aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${name}`}
+}) => {
+  const showActions = !isEditing;
+
+  return (
+    <div className="space-y-2">
+      <div
+        className="group mb-2 flex items-center justify-between rounded-md px-2 py-1 text-[0.65rem] uppercase tracking-widest text-text-secondary/70"
+        draggable={!isEditing}
+        onDragStart={event => {
+          if (isEditing) {
+            event.preventDefault();
+            return;
+          }
+          onDragStart(event);
+        }}
+        onDragEnd={onDragEnd}
+        onKeyDown={onKeyDown}
+        tabIndex={isEditing ? -1 : 0}
+        role="button"
+        aria-grabbed={isDragging}
+        data-category-id={categoryId}
       >
-        {isCollapsed ? '▸' : '▾'}
-      </button>
-    </div>
-    {isEditing ? (
-      <div className="mb-3">
-        <label className="sr-only" htmlFor={`rename-${categoryId}`}>
-          {labels.renameCategory}
-        </label>
-        <input
-          id={`rename-${categoryId}`}
-          className="w-full rounded-md border border-border-color bg-surface px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          value={editingValue}
-          onChange={event => onRenameChange(categoryId, event.target.value)}
-          onKeyDown={onRenameKeyDown}
-          onBlur={onRenameBlur}
-          autoFocus
-        />
-        {editingError ? <p className="mt-1 text-xs text-red-500">{editingError}</p> : null}
+        <div className="flex flex-1 items-center gap-2 overflow-hidden">
+          <div
+            className={`flex items-center gap-1 overflow-hidden transition-[width,opacity] duration-200 ease-out ${
+              showActions
+                ? 'w-0 opacity-0 group-hover:w-[3.5rem] group-hover:opacity-100 group-focus-within:w-[3.5rem] group-focus-within:opacity-100'
+                : 'w-0 opacity-0'
+            }`}
+            aria-hidden={!showActions}
+          >
+            {showActions ? (
+              <>
+                <button
+                  type="button"
+                  className="flex h-6 w-6 items-center justify-center rounded-full bg-blue-500 text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={onBeginRename}
+                  aria-label={labels.renameCategory}
+                >
+                  🔧
+                </button>
+                <button
+                  type="button"
+                  className="flex h-6 w-6 items-center justify-center rounded-full bg-red-500 text-white shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  onClick={onDelete}
+                  aria-label={labels.deleteCategory}
+                >
+                  ✕
+                </button>
+              </>
+            ) : null}
+          </div>
+          <span className="truncate">{name}</span>
+        </div>
+        <button
+          type="button"
+          className="ml-2 text-xs text-text-secondary"
+          onClick={onToggleCollapse}
+          aria-label={`${isCollapsed ? 'Expand' : 'Collapse'} ${name}`}
+        >
+          {isCollapsed ? '▸' : '▾'}
+        </button>
       </div>
-    ) : null}
-  </div>
-);
+      {isEditing ? (
+        <div className="px-2">
+          <label className="sr-only" htmlFor={`rename-${categoryId}`}>
+            {labels.renameCategory}
+          </label>
+          <input
+            id={`rename-${categoryId}`}
+            className="w-full rounded-md border border-border-color bg-surface px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            value={editingValue}
+            onChange={event => onRenameChange(categoryId, event.target.value)}
+            onKeyDown={onRenameKeyDown}
+            onBlur={onRenameBlur}
+            onFocus={event => event.currentTarget.select()}
+            autoFocus
+          />
+          {editingError ? <p className="mt-1 text-xs text-red-500">{editingError}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+};

--- a/components/layouts/sidebarOrganizer/CategorySection.tsx
+++ b/components/layouts/sidebarOrganizer/CategorySection.tsx
@@ -95,6 +95,8 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
             featureDropTarget.index === 0 &&
             featureDropTarget.context === 'zone'
           }
+          sizeClassName={collapsed ? 'h-4' : 'h-6'}
+          className={collapsed ? '' : 'px-2'}
           onDragOver={event => {
             if (draggingItem?.type !== 'feature') {
               const data = parseDragData(event);
@@ -125,6 +127,7 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
             }
             event.preventDefault();
             onFeatureDrop(data.id, null, 0);
+            setFeatureDropTarget(null);
           }}
         />
         <FeatureList
@@ -246,6 +249,7 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
       <DropZone
         active={isCategoryDropTarget}
         sizeClassName="h-3"
+        className="px-2"
         onDragOver={event => {
           if (draggingItem?.type !== 'category') {
             const data = parseDragData(event);

--- a/components/layouts/sidebarOrganizer/CategorySection.tsx
+++ b/components/layouts/sidebarOrganizer/CategorySection.tsx
@@ -83,9 +83,11 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
   parseDragData,
   onSelectMode,
 }) => {
+  const sectionSpacing = collapsed ? 'px-1 first:pt-2 last:pb-2' : 'px-2 py-3';
+
   if (bucket.categoryId === null) {
     return (
-      <div className="px-2">
+      <div className={sectionSpacing}>
         <DropZone
           active={featureDropTarget?.categoryId === null && featureDropTarget.index === 0}
           onDragOver={event => {
@@ -128,8 +130,33 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
     );
   }
 
+  if (collapsed) {
+    return (
+      <div className={sectionSpacing}>
+        <FeatureList
+          bucket={bucket}
+          collapsed={collapsed}
+          activeMode={activeMode}
+          iconMap={iconMap}
+          tabLabels={tabLabels}
+          draggingItem={draggingItem}
+          featureDropTarget={featureDropTarget}
+          onSelectMode={onSelectMode}
+          onDragStart={onFeatureDragStart}
+          onDragEnd={onFeatureDragEnd}
+          onKeyDown={onFeatureKeyDown}
+          onDrop={onFeatureDrop}
+          setFeatureDropTarget={setFeatureDropTarget}
+          parseDragData={parseDragData}
+        />
+      </div>
+    );
+  }
+
+  const isCollapsed = collapsedCategoryIds.includes(bucket.categoryId);
+
   return (
-    <div className="px-2">
+    <div className={sectionSpacing}>
       <DropZone
         active={categoryDropTarget?.targetIndex === bucketIndex}
         sizeClassName="h-3"
@@ -153,10 +180,9 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
       <CategoryHeader
         categoryId={bucket.categoryId}
         name={bucket.title ?? ''}
-        collapsed={collapsed}
         isDragging={draggingItem?.type === 'category' && draggingItem.id === bucket.categoryId}
         labels={mergedLabels}
-        isCollapsed={collapsedCategoryIds.includes(bucket.categoryId)}
+        isCollapsed={isCollapsed}
         isEditing={editingCategoryId === bucket.categoryId}
         editingValue={editingName}
         editingError={editingError}
@@ -170,7 +196,7 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
         onDragEnd={onCategoryDragEnd}
         onKeyDown={event => onCategoryKeyDown(event, bucket.categoryId!)}
       />
-      {!collapsedCategoryIds.includes(bucket.categoryId) ? (
+      {!isCollapsed ? (
         <FeatureList
           bucket={bucket}
           collapsed={collapsed}

--- a/components/layouts/sidebarOrganizer/CategorySection.tsx
+++ b/components/layouts/sidebarOrganizer/CategorySection.tsx
@@ -91,18 +91,24 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
         <DropZone
           active={featureDropTarget?.categoryId === null && featureDropTarget.index === 0}
           onDragOver={event => {
-            const data = parseDragData(event);
-            if (data?.type !== 'feature') {
-              return;
+            if (draggingItem?.type !== 'feature') {
+              const data = parseDragData(event);
+              if (data?.type !== 'feature') {
+                return;
+              }
             }
             event.preventDefault();
+            if (event.dataTransfer) {
+              event.dataTransfer.dropEffect = 'move';
+            }
             setFeatureDropTarget({ categoryId: null, index: 0 });
           }}
           onDragLeave={() => {
             setFeatureDropTarget(prev => (prev?.categoryId === null ? null : prev));
           }}
           onDrop={event => {
-            const data = parseDragData(event);
+            const data =
+              draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
             if (data?.type !== 'feature') {
               return;
             }
@@ -155,26 +161,39 @@ export const CategorySection: React.FC<CategorySectionProps> = ({
 
   const isCollapsed = collapsedCategoryIds.includes(bucket.categoryId);
 
+  const categoryInsertionIndex = Math.max(0, bucketIndex - 1);
+
   return (
     <div className={sectionSpacing}>
       <DropZone
-        active={categoryDropTarget?.targetIndex === bucketIndex}
+        active={categoryDropTarget?.targetIndex === categoryInsertionIndex}
         sizeClassName="h-3"
         onDragOver={event => {
-          const data = parseDragData(event);
-          if (data?.type !== 'category') {
-            return;
+          if (draggingItem?.type !== 'category') {
+            const data = parseDragData(event);
+            if (data?.type !== 'category') {
+              return;
+            }
           }
           event.preventDefault();
-          setCategoryDropTarget({ targetIndex: bucketIndex });
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+          }
+          setCategoryDropTarget({ targetIndex: categoryInsertionIndex });
+        }}
+        onDragLeave={() => {
+          setCategoryDropTarget(prev =>
+            prev?.targetIndex === categoryInsertionIndex ? null : prev,
+          );
         }}
         onDrop={event => {
-          const data = parseDragData(event);
+          const data =
+            draggingItem?.type === 'category' ? draggingItem : parseDragData(event);
           if (data?.type !== 'category') {
             return;
           }
           event.preventDefault();
-          onCategoryDrop(data.id, bucketIndex);
+          onCategoryDrop(data.id, categoryInsertionIndex);
         }}
       />
       <CategoryHeader

--- a/components/layouts/sidebarOrganizer/CategorySection.tsx
+++ b/components/layouts/sidebarOrganizer/CategorySection.tsx
@@ -1,0 +1,193 @@
+/**
+ * @fileoverview Component that renders a single category section including its header and feature list.
+ */
+
+import React from 'react';
+import { CategoryHeader } from './CategoryHeader';
+import { FeatureList } from './FeatureList';
+import type { LayoutBucket } from './useLayoutBuckets';
+import type { DraggingItem, FeatureDropTarget, CategoryDropTarget } from './dragTypes';
+import type { Mode } from '../../../types';
+import type { SidebarOrganizerLabels, ModeIconMap } from './types';
+import { DropZone } from './DropZone';
+
+interface CategorySectionProps {
+  bucket: LayoutBucket;
+  bucketIndex: number;
+  collapsed: boolean;
+  activeMode: Mode;
+  iconMap: ModeIconMap;
+  tabLabels: Record<Mode, string>;
+  draggingItem: DraggingItem | null;
+  featureDropTarget: FeatureDropTarget;
+  categoryDropTarget: CategoryDropTarget;
+  mergedLabels: SidebarOrganizerLabels;
+  collapsedCategoryIds: string[];
+  editingCategoryId: string | null;
+  editingName: string;
+  editingError: string | null;
+  onToggleCollapse: (categoryId: string) => void;
+  onBeginRename: (categoryId: string, name: string) => void;
+  onDeleteCategory: (categoryId: string) => void;
+  onRenameChange: (categoryId: string, value: string) => void;
+  onRenameKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onRenameBlur: () => void;
+  onFeatureKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>, featureId: string) => void;
+  onFeatureDragStart: (event: React.DragEvent<HTMLButtonElement>, featureId: string) => void;
+  onFeatureDragEnd: () => void;
+  onFeatureDrop: (featureId: string, categoryId: string | null, index: number) => void;
+  onCategoryDragStart: (event: React.DragEvent<HTMLDivElement>, categoryId: string) => void;
+  onCategoryDragEnd: () => void;
+  onCategoryKeyDown: (event: React.KeyboardEvent<HTMLDivElement>, categoryId: string) => void;
+  onCategoryDrop: (categoryId: string, targetIndex: number) => void;
+  setFeatureDropTarget: React.Dispatch<React.SetStateAction<FeatureDropTarget>>;
+  setCategoryDropTarget: React.Dispatch<React.SetStateAction<CategoryDropTarget>>;
+  parseDragData: (event: React.DragEvent) => DraggingItem | null;
+  onSelectMode?: (mode: Mode) => void;
+}
+
+/**
+ * Renders a category bucket including drop zones for categories and features.
+ */
+export const CategorySection: React.FC<CategorySectionProps> = ({
+  bucket,
+  bucketIndex,
+  collapsed,
+  activeMode,
+  iconMap,
+  tabLabels,
+  draggingItem,
+  featureDropTarget,
+  categoryDropTarget,
+  mergedLabels,
+  collapsedCategoryIds,
+  editingCategoryId,
+  editingName,
+  editingError,
+  onToggleCollapse,
+  onBeginRename,
+  onDeleteCategory,
+  onRenameChange,
+  onRenameKeyDown,
+  onRenameBlur,
+  onFeatureKeyDown,
+  onFeatureDragStart,
+  onFeatureDragEnd,
+  onFeatureDrop,
+  onCategoryDragStart,
+  onCategoryDragEnd,
+  onCategoryKeyDown,
+  onCategoryDrop,
+  setFeatureDropTarget,
+  setCategoryDropTarget,
+  parseDragData,
+  onSelectMode,
+}) => {
+  if (bucket.categoryId === null) {
+    return (
+      <div className="px-2">
+        <DropZone
+          active={featureDropTarget?.categoryId === null && featureDropTarget.index === 0}
+          onDragOver={event => {
+            const data = parseDragData(event);
+            if (data?.type !== 'feature') {
+              return;
+            }
+            event.preventDefault();
+            setFeatureDropTarget({ categoryId: null, index: 0 });
+          }}
+          onDragLeave={() => {
+            setFeatureDropTarget(prev => (prev?.categoryId === null ? null : prev));
+          }}
+          onDrop={event => {
+            const data = parseDragData(event);
+            if (data?.type !== 'feature') {
+              return;
+            }
+            event.preventDefault();
+            onFeatureDrop(data.id, null, 0);
+          }}
+        />
+        <FeatureList
+          bucket={bucket}
+          collapsed={collapsed}
+          activeMode={activeMode}
+          iconMap={iconMap}
+          tabLabels={tabLabels}
+          draggingItem={draggingItem}
+          featureDropTarget={featureDropTarget}
+          onSelectMode={onSelectMode}
+          onDragStart={onFeatureDragStart}
+          onDragEnd={onFeatureDragEnd}
+          onKeyDown={onFeatureKeyDown}
+          onDrop={onFeatureDrop}
+          setFeatureDropTarget={setFeatureDropTarget}
+          parseDragData={parseDragData}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-2">
+      <DropZone
+        active={categoryDropTarget?.targetIndex === bucketIndex}
+        sizeClassName="h-3"
+        onDragOver={event => {
+          const data = parseDragData(event);
+          if (data?.type !== 'category') {
+            return;
+          }
+          event.preventDefault();
+          setCategoryDropTarget({ targetIndex: bucketIndex });
+        }}
+        onDrop={event => {
+          const data = parseDragData(event);
+          if (data?.type !== 'category') {
+            return;
+          }
+          event.preventDefault();
+          onCategoryDrop(data.id, bucketIndex);
+        }}
+      />
+      <CategoryHeader
+        categoryId={bucket.categoryId}
+        name={bucket.title ?? ''}
+        collapsed={collapsed}
+        isDragging={draggingItem?.type === 'category' && draggingItem.id === bucket.categoryId}
+        labels={mergedLabels}
+        isCollapsed={collapsedCategoryIds.includes(bucket.categoryId)}
+        isEditing={editingCategoryId === bucket.categoryId}
+        editingValue={editingName}
+        editingError={editingError}
+        onToggleCollapse={() => onToggleCollapse(bucket.categoryId!)}
+        onBeginRename={() => onBeginRename(bucket.categoryId!, bucket.title ?? '')}
+        onDelete={() => onDeleteCategory(bucket.categoryId!)}
+        onRenameChange={onRenameChange}
+        onRenameKeyDown={onRenameKeyDown}
+        onRenameBlur={onRenameBlur}
+        onDragStart={event => onCategoryDragStart(event, bucket.categoryId!)}
+        onDragEnd={onCategoryDragEnd}
+        onKeyDown={event => onCategoryKeyDown(event, bucket.categoryId!)}
+      />
+      {!collapsedCategoryIds.includes(bucket.categoryId) ? (
+        <FeatureList
+          bucket={bucket}
+          collapsed={collapsed}
+          activeMode={activeMode}
+          iconMap={iconMap}
+          tabLabels={tabLabels}
+          draggingItem={draggingItem}
+          featureDropTarget={featureDropTarget}
+          onSelectMode={onSelectMode}
+          onDragStart={onFeatureDragStart}
+          onDragEnd={onFeatureDragEnd}
+          onKeyDown={onFeatureKeyDown}
+          onDrop={onFeatureDrop}
+          setFeatureDropTarget={setFeatureDropTarget}
+          parseDragData={parseDragData}
+        />
+      ) : null}
+    </div>
+  );
+};

--- a/components/layouts/sidebarOrganizer/DropZone.tsx
+++ b/components/layouts/sidebarOrganizer/DropZone.tsx
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Lightweight drop zone component used for drag-and-drop placeholders.
+ */
+
+import React from 'react';
+
+interface DropZoneProps {
+  /** Whether the drop zone is currently highlighted. */
+  active: boolean;
+  /** Invoked when a draggable element moves over the zone. */
+  onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
+  /** Triggered when the draggable leaves the zone without dropping. */
+  onDragLeave?: () => void;
+  /** Fires when the draggable is dropped. */
+  onDrop: (event: React.DragEvent<HTMLDivElement>) => void;
+  /** Optional custom height classes. */
+  sizeClassName?: string;
+}
+
+/**
+ * Visual placeholder for drag targets.
+ */
+export const DropZone: React.FC<DropZoneProps> = ({
+  active,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  sizeClassName = 'h-2',
+}) => (
+  <div
+    className={`${sizeClassName} rounded transition-all duration-150 ease-out ${
+      active ? 'bg-primary/40' : 'bg-transparent'
+    }`}
+    onDragOver={onDragOver}
+    onDragLeave={onDragLeave}
+    onDrop={onDrop}
+  />
+);

--- a/components/layouts/sidebarOrganizer/DropZone.tsx
+++ b/components/layouts/sidebarOrganizer/DropZone.tsx
@@ -10,11 +10,13 @@ interface DropZoneProps {
   /** Invoked when a draggable element moves over the zone. */
   onDragOver: (event: React.DragEvent<HTMLDivElement>) => void;
   /** Triggered when the draggable leaves the zone without dropping. */
-  onDragLeave?: () => void;
+  onDragLeave?: (event: React.DragEvent<HTMLDivElement>) => void;
   /** Fires when the draggable is dropped. */
   onDrop: (event: React.DragEvent<HTMLDivElement>) => void;
   /** Optional custom height classes. */
   sizeClassName?: string;
+  /** Additional custom classes for the container. */
+  className?: string;
 }
 
 /**
@@ -26,13 +28,19 @@ export const DropZone: React.FC<DropZoneProps> = ({
   onDragLeave,
   onDrop,
   sizeClassName = 'h-2',
+  className = '',
 }) => (
   <div
-    className={`${sizeClassName} rounded transition-all duration-150 ease-out ${
-      active ? 'bg-primary/40' : 'bg-transparent'
-    }`}
+    className={`relative flex items-center ${sizeClassName} ${className}`}
     onDragOver={onDragOver}
     onDragLeave={onDragLeave}
     onDrop={onDrop}
-  />
+  >
+    <span
+      aria-hidden
+      className={`pointer-events-none h-1 w-full rounded-full transition-colors duration-150 ${
+        active ? 'bg-primary' : 'bg-transparent'
+      }`}
+    />
+  </div>
 );

--- a/components/layouts/sidebarOrganizer/FeatureItem.tsx
+++ b/components/layouts/sidebarOrganizer/FeatureItem.tsx
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Reusable component for rendering a sidebar feature entry.
+ */
+
+import React from 'react';
+import type { Mode } from '../../../types';
+import type { ModeIconMap } from './types';
+import type { SidebarFeature } from './types';
+
+interface FeatureItemProps {
+  /** Feature metadata representing the shortcut entry. */
+  feature: SidebarFeature;
+  /** Whether the sidebar is collapsed into icon-only mode. */
+  collapsed: boolean;
+  /** Currently active mode used for highlighting. */
+  activeMode: Mode;
+  /** Icon registry for the workspace modes. */
+  iconMap: ModeIconMap;
+  /** Localized label lookup keyed by mode. */
+  tabLabels: Record<Mode, string>;
+  /** Indicates that the feature is being dragged. */
+  isDragging: boolean;
+  /** Callback triggered when the entry is selected. */
+  onSelectMode?: (mode: Mode) => void;
+  /** Keyboard handler supporting drag shortcuts. */
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>, featureId: string) => void;
+  /** Pointer drag start handler. */
+  onDragStart: (event: React.DragEvent<HTMLButtonElement>, featureId: string) => void;
+  /** Pointer drag end handler. */
+  onDragEnd: () => void;
+}
+
+/**
+ * Visual representation of a feature with drag, keyboard, and selection affordances.
+ */
+export const FeatureItem: React.FC<FeatureItemProps> = ({
+  feature,
+  collapsed,
+  activeMode,
+  iconMap,
+  tabLabels,
+  isDragging,
+  onSelectMode,
+  onKeyDown,
+  onDragStart,
+  onDragEnd,
+}) => {
+  const IconComponent = iconMap[feature.mode];
+  const isActive = activeMode === feature.mode;
+  const buttonClasses = [
+    'group flex w-full items-center gap-3 rounded-md px-2 py-2 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-surface',
+    isActive
+      ? 'bg-primary/20 text-primary'
+      : 'text-text-secondary hover:bg-secondary/60 hover:text-text-primary focus-visible:text-text-primary',
+    collapsed ? 'justify-center px-0' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <button
+      type="button"
+      className={buttonClasses}
+      draggable
+      onDragStart={event => onDragStart(event, feature.id)}
+      onDragEnd={onDragEnd}
+      onKeyDown={event => onKeyDown(event, feature.id)}
+      onClick={() => onSelectMode?.(feature.mode)}
+      aria-grabbed={isDragging}
+      role="listitem"
+    >
+      {IconComponent ? (
+        <IconComponent
+          fontSize={collapsed ? 'large' : 'medium'}
+          className={`shrink-0 ${isActive ? 'text-primary' : 'text-text-secondary'} ${collapsed ? 'mx-auto' : ''}`}
+        />
+      ) : null}
+      {collapsed ? (
+        <span className="sr-only">{tabLabels[feature.mode]}</span>
+      ) : (
+        <span className="truncate">{tabLabels[feature.mode]}</span>
+      )}
+    </button>
+  );
+};

--- a/components/layouts/sidebarOrganizer/FeatureItem.tsx
+++ b/components/layouts/sidebarOrganizer/FeatureItem.tsx
@@ -20,8 +20,6 @@ interface FeatureItemProps {
   tabLabels: Record<Mode, string>;
   /** Indicates that the feature is being dragged. */
   isDragging: boolean;
-  /** Highlights the feature when it is the active drop location. */
-  isDropTarget: boolean;
   /** Callback triggered when the entry is selected. */
   onSelectMode?: (mode: Mode) => void;
   /** Keyboard handler supporting drag shortcuts. */
@@ -42,7 +40,6 @@ export const FeatureItem: React.FC<FeatureItemProps> = ({
   iconMap,
   tabLabels,
   isDragging,
-  isDropTarget,
   onSelectMode,
   onKeyDown,
   onDragStart,
@@ -56,7 +53,6 @@ export const FeatureItem: React.FC<FeatureItemProps> = ({
       ? 'bg-primary/20 text-primary'
       : 'text-text-secondary hover:bg-secondary/60 hover:text-text-primary focus-visible:text-text-primary',
     collapsed ? 'justify-center px-0' : '',
-    isDropTarget ? 'bg-primary/10 ring-2 ring-primary/60 ring-offset-1 ring-offset-surface' : '',
   ]
     .filter(Boolean)
     .join(' ');

--- a/components/layouts/sidebarOrganizer/FeatureItem.tsx
+++ b/components/layouts/sidebarOrganizer/FeatureItem.tsx
@@ -20,6 +20,8 @@ interface FeatureItemProps {
   tabLabels: Record<Mode, string>;
   /** Indicates that the feature is being dragged. */
   isDragging: boolean;
+  /** Highlights the feature when it is the active drop location. */
+  isDropTarget: boolean;
   /** Callback triggered when the entry is selected. */
   onSelectMode?: (mode: Mode) => void;
   /** Keyboard handler supporting drag shortcuts. */
@@ -40,6 +42,7 @@ export const FeatureItem: React.FC<FeatureItemProps> = ({
   iconMap,
   tabLabels,
   isDragging,
+  isDropTarget,
   onSelectMode,
   onKeyDown,
   onDragStart,
@@ -53,6 +56,7 @@ export const FeatureItem: React.FC<FeatureItemProps> = ({
       ? 'bg-primary/20 text-primary'
       : 'text-text-secondary hover:bg-secondary/60 hover:text-text-primary focus-visible:text-text-primary',
     collapsed ? 'justify-center px-0' : '',
+    isDropTarget ? 'bg-primary/10 ring-2 ring-primary/60 ring-offset-1 ring-offset-surface' : '',
   ]
     .filter(Boolean)
     .join(' ');
@@ -67,6 +71,7 @@ export const FeatureItem: React.FC<FeatureItemProps> = ({
       onKeyDown={event => onKeyDown(event, feature.id)}
       onClick={() => onSelectMode?.(feature.mode)}
       aria-grabbed={isDragging}
+      data-feature-id={feature.id}
       role="listitem"
     >
       {IconComponent ? (

--- a/components/layouts/sidebarOrganizer/FeatureList.tsx
+++ b/components/layouts/sidebarOrganizer/FeatureList.tsx
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Component that renders feature rows and their drag-and-drop drop zones.
+ */
+
+import React from 'react';
+import type { Mode } from '../../../types';
+import { DropZone } from './DropZone';
+import { FeatureItem } from './FeatureItem';
+import type { LayoutBucket } from './useLayoutBuckets';
+import type { DraggingItem, FeatureDropTarget } from './dragTypes';
+import type { ModeIconMap } from './types';
+
+interface FeatureListProps {
+  bucket: LayoutBucket;
+  collapsed: boolean;
+  activeMode: Mode;
+  iconMap: ModeIconMap;
+  tabLabels: Record<Mode, string>;
+  draggingItem: DraggingItem | null;
+  featureDropTarget: FeatureDropTarget;
+  onSelectMode?: (mode: Mode) => void;
+  onDragStart: (event: React.DragEvent<HTMLButtonElement>, featureId: string) => void;
+  onDragEnd: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>, featureId: string) => void;
+  onDrop: (featureId: string, categoryId: string | null, index: number) => void;
+  setFeatureDropTarget: React.Dispatch<React.SetStateAction<FeatureDropTarget>>;
+  parseDragData: (event: React.DragEvent) => DraggingItem | null;
+}
+
+/**
+ * Visualizes all features for a specific bucket, wiring up drag drop slots.
+ */
+export const FeatureList: React.FC<FeatureListProps> = ({
+  bucket,
+  collapsed,
+  activeMode,
+  iconMap,
+  tabLabels,
+  draggingItem,
+  featureDropTarget,
+  onSelectMode,
+  onDragStart,
+  onDragEnd,
+  onKeyDown,
+  onDrop,
+  setFeatureDropTarget,
+  parseDragData,
+}) => (
+  <ul role="list" className="space-y-1">
+    {bucket.features.map((feature, index) => (
+      <React.Fragment key={feature.id}>
+        <DropZone
+          active={featureDropTarget?.categoryId === bucket.categoryId && featureDropTarget.index === index}
+          onDragOver={event => {
+            const data = parseDragData(event);
+            if (data?.type !== 'feature') {
+              return;
+            }
+            event.preventDefault();
+            setFeatureDropTarget({ categoryId: bucket.categoryId, index });
+          }}
+          onDragLeave={() => {
+            setFeatureDropTarget(prev =>
+              prev?.categoryId === bucket.categoryId && prev.index === index ? null : prev,
+            );
+          }}
+          onDrop={event => {
+            const data = parseDragData(event);
+            if (data?.type !== 'feature') {
+              return;
+            }
+            event.preventDefault();
+            onDrop(data.id, bucket.categoryId, index);
+          }}
+        />
+        <li>
+          <FeatureItem
+            feature={feature}
+            collapsed={collapsed}
+            activeMode={activeMode}
+            iconMap={iconMap}
+            tabLabels={tabLabels}
+            isDragging={draggingItem?.type === 'feature' && draggingItem.id === feature.id}
+            onSelectMode={onSelectMode}
+            onKeyDown={onKeyDown}
+            onDragStart={onDragStart}
+            onDragEnd={onDragEnd}
+          />
+        </li>
+      </React.Fragment>
+    ))}
+    <DropZone
+      active={
+        featureDropTarget?.categoryId === bucket.categoryId &&
+        featureDropTarget.index === bucket.features.length
+      }
+      onDragOver={event => {
+        const data = parseDragData(event);
+        if (data?.type !== 'feature') {
+          return;
+        }
+        event.preventDefault();
+        setFeatureDropTarget({ categoryId: bucket.categoryId, index: bucket.features.length });
+      }}
+      onDragLeave={() => {
+        setFeatureDropTarget(prev =>
+          prev?.categoryId === bucket.categoryId && prev.index === bucket.features.length ? null : prev,
+        );
+      }}
+      onDrop={event => {
+        const data = parseDragData(event);
+        if (data?.type !== 'feature') {
+          return;
+        }
+        event.preventDefault();
+        onDrop(data.id, bucket.categoryId, bucket.features.length);
+      }}
+    />
+  </ul>
+);

--- a/components/layouts/sidebarOrganizer/FeatureList.tsx
+++ b/components/layouts/sidebarOrganizer/FeatureList.tsx
@@ -45,88 +45,120 @@ export const FeatureList: React.FC<FeatureListProps> = ({
   onDrop,
   setFeatureDropTarget,
   parseDragData,
-}) => (
-  <ul role="list" className="space-y-1">
-    {bucket.features.map((feature, index) => (
-      <React.Fragment key={feature.id}>
-        <DropZone
-          active={featureDropTarget?.categoryId === bucket.categoryId && featureDropTarget.index === index}
-          onDragOver={event => {
-            if (draggingItem?.type !== 'feature') {
-              const data = parseDragData(event);
+}) => {
+  const isActiveDropTarget = (index: number) =>
+    featureDropTarget?.categoryId === bucket.categoryId &&
+    featureDropTarget.index === index &&
+    featureDropTarget.context === 'item';
+
+  return (
+    <ul role="list" className="space-y-1">
+      {bucket.features.map((feature, index) => (
+        <li key={feature.id}>
+          <div
+            className={`rounded-md ${
+              isActiveDropTarget(index) ? 'bg-primary/10 ring-2 ring-primary/60 ring-offset-1 ring-offset-surface' : ''
+            }`}
+            onDragOver={event => {
+              if (draggingItem?.type !== 'feature') {
+                const data = parseDragData(event);
+                if (data?.type !== 'feature') {
+                  return;
+                }
+              }
+              event.preventDefault();
+              if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'move';
+              }
+              setFeatureDropTarget({
+                categoryId: bucket.categoryId,
+                index,
+                context: 'item',
+              });
+            }}
+            onDragLeave={event => {
+              const related = event.relatedTarget as Node | null;
+              if (related && event.currentTarget.contains(related)) {
+                return;
+              }
+              setFeatureDropTarget(prev =>
+                prev?.categoryId === bucket.categoryId && prev.index === index && prev.context === 'item'
+                  ? null
+                  : prev,
+              );
+            }}
+            onDrop={event => {
+              const data = draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
               if (data?.type !== 'feature') {
                 return;
               }
-            }
-            event.preventDefault();
-            if (event.dataTransfer) {
-              event.dataTransfer.dropEffect = 'move';
-            }
-            setFeatureDropTarget({ categoryId: bucket.categoryId, index });
-          }}
-          onDragLeave={() => {
-            setFeatureDropTarget(prev =>
-              prev?.categoryId === bucket.categoryId && prev.index === index ? null : prev,
-            );
-          }}
-          onDrop={event => {
-            const data =
-              draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
+              event.preventDefault();
+              event.stopPropagation();
+              onDrop(data.id, bucket.categoryId, index);
+            }}
+          >
+            <FeatureItem
+              feature={feature}
+              collapsed={collapsed}
+              activeMode={activeMode}
+              iconMap={iconMap}
+              tabLabels={tabLabels}
+              isDragging={draggingItem?.type === 'feature' && draggingItem.id === feature.id}
+              isDropTarget={isActiveDropTarget(index)}
+              onSelectMode={onSelectMode}
+              onKeyDown={onKeyDown}
+              onDragStart={onDragStart}
+              onDragEnd={onDragEnd}
+            />
+          </div>
+        </li>
+      ))}
+      <DropZone
+        active={
+          featureDropTarget?.categoryId === bucket.categoryId &&
+          featureDropTarget.index === bucket.features.length &&
+          featureDropTarget.context === 'zone'
+        }
+        sizeClassName={bucket.features.length === 0 ? 'h-12' : 'h-3'}
+        onDragOver={event => {
+          if (draggingItem?.type !== 'feature') {
+            const data = parseDragData(event);
             if (data?.type !== 'feature') {
               return;
             }
-            event.preventDefault();
-            onDrop(data.id, bucket.categoryId, index);
-          }}
-        />
-        <li>
-          <FeatureItem
-            feature={feature}
-            collapsed={collapsed}
-            activeMode={activeMode}
-            iconMap={iconMap}
-            tabLabels={tabLabels}
-            isDragging={draggingItem?.type === 'feature' && draggingItem.id === feature.id}
-            onSelectMode={onSelectMode}
-            onKeyDown={onKeyDown}
-            onDragStart={onDragStart}
-            onDragEnd={onDragEnd}
-          />
-        </li>
-      </React.Fragment>
-    ))}
-    <DropZone
-      active={
-        featureDropTarget?.categoryId === bucket.categoryId &&
-        featureDropTarget.index === bucket.features.length
-      }
-      onDragOver={event => {
-        if (draggingItem?.type !== 'feature') {
-          const data = parseDragData(event);
+          }
+          event.preventDefault();
+          if (event.dataTransfer) {
+            event.dataTransfer.dropEffect = 'move';
+          }
+          setFeatureDropTarget({
+            categoryId: bucket.categoryId,
+            index: bucket.features.length,
+            context: 'zone',
+          });
+        }}
+        onDragLeave={event => {
+          const related = event.relatedTarget as Node | null;
+          if (related && event.currentTarget.contains(related)) {
+            return;
+          }
+          setFeatureDropTarget(prev =>
+            prev?.categoryId === bucket.categoryId &&
+            prev.index === bucket.features.length &&
+            prev.context === 'zone'
+              ? null
+              : prev,
+          );
+        }}
+        onDrop={event => {
+          const data = draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
           if (data?.type !== 'feature') {
             return;
           }
-        }
-        event.preventDefault();
-        if (event.dataTransfer) {
-          event.dataTransfer.dropEffect = 'move';
-        }
-        setFeatureDropTarget({ categoryId: bucket.categoryId, index: bucket.features.length });
-      }}
-      onDragLeave={() => {
-        setFeatureDropTarget(prev =>
-          prev?.categoryId === bucket.categoryId && prev.index === bucket.features.length ? null : prev,
-        );
-      }}
-      onDrop={event => {
-        const data =
-          draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
-        if (data?.type !== 'feature') {
-          return;
-        }
-        event.preventDefault();
-        onDrop(data.id, bucket.categoryId, bucket.features.length);
-      }}
-    />
-  </ul>
-);
+          event.preventDefault();
+          onDrop(data.id, bucket.categoryId, bucket.features.length);
+        }}
+      />
+    </ul>
+  );
+};

--- a/components/layouts/sidebarOrganizer/FeatureList.tsx
+++ b/components/layouts/sidebarOrganizer/FeatureList.tsx
@@ -52,11 +52,16 @@ export const FeatureList: React.FC<FeatureListProps> = ({
         <DropZone
           active={featureDropTarget?.categoryId === bucket.categoryId && featureDropTarget.index === index}
           onDragOver={event => {
-            const data = parseDragData(event);
-            if (data?.type !== 'feature') {
-              return;
+            if (draggingItem?.type !== 'feature') {
+              const data = parseDragData(event);
+              if (data?.type !== 'feature') {
+                return;
+              }
             }
             event.preventDefault();
+            if (event.dataTransfer) {
+              event.dataTransfer.dropEffect = 'move';
+            }
             setFeatureDropTarget({ categoryId: bucket.categoryId, index });
           }}
           onDragLeave={() => {
@@ -65,7 +70,8 @@ export const FeatureList: React.FC<FeatureListProps> = ({
             );
           }}
           onDrop={event => {
-            const data = parseDragData(event);
+            const data =
+              draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
             if (data?.type !== 'feature') {
               return;
             }
@@ -95,11 +101,16 @@ export const FeatureList: React.FC<FeatureListProps> = ({
         featureDropTarget.index === bucket.features.length
       }
       onDragOver={event => {
-        const data = parseDragData(event);
-        if (data?.type !== 'feature') {
-          return;
+        if (draggingItem?.type !== 'feature') {
+          const data = parseDragData(event);
+          if (data?.type !== 'feature') {
+            return;
+          }
         }
         event.preventDefault();
+        if (event.dataTransfer) {
+          event.dataTransfer.dropEffect = 'move';
+        }
         setFeatureDropTarget({ categoryId: bucket.categoryId, index: bucket.features.length });
       }}
       onDragLeave={() => {
@@ -108,7 +119,8 @@ export const FeatureList: React.FC<FeatureListProps> = ({
         );
       }}
       onDrop={event => {
-        const data = parseDragData(event);
+        const data =
+          draggingItem?.type === 'feature' ? draggingItem : parseDragData(event);
         if (data?.type !== 'feature') {
           return;
         }

--- a/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
+++ b/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
@@ -1,0 +1,217 @@
+/**
+ * @fileoverview React component composing the sidebar organizer experience with drag-and-drop, rename, and persistence support.
+ * The component relies exclusively on browser APIs and local state; it does not issue network requests and therefore needs no
+ * explicit timeout management.
+ */
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import type { Mode } from '../../../types';
+import { TABS } from '../../../constants/uiConstants';
+import { DropZone } from './DropZone';
+import { CategorySection } from './CategorySection';
+import { moveCategory, toggleCategory } from './actions';
+import type { ModeIconMap, SidebarOrganizerLabels } from './types';
+import { useSidebarOrganizationState } from './useSidebarOrganizationState';
+import { useLayoutBuckets } from './useLayoutBuckets';
+import { useSidebarOrganizerActions } from './useSidebarOrganizerActions';
+
+interface SidebarOrganizerProps {
+  collapsed: boolean;
+  activeMode: Mode;
+  onSelectMode?: (mode: Mode) => void;
+  iconMap: ModeIconMap;
+  labels?: Partial<SidebarOrganizerLabels>;
+}
+
+/**
+ * Derives a quick lookup between mode identifiers and human-readable labels.
+ */
+const useTabLabelMap = (): Record<Mode, string> =>
+  useMemo(
+    () =>
+      TABS.reduce<Record<Mode, string>>((acc, tab) => {
+        acc[tab.id as Mode] = tab.label;
+        return acc;
+      }, {} as Record<Mode, string>),
+    [],
+  );
+
+/**
+ * Broadcasts messages to an aria-live region for assistive technologies.
+ */
+const useAnnouncement = (): [React.MutableRefObject<HTMLDivElement | null>, (message: string) => void] => {
+  const regionRef = useRef<HTMLDivElement | null>(null);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (regionRef.current) {
+      regionRef.current.textContent = message;
+    }
+  }, [message]);
+
+  const announce = (text: string) => {
+    setMessage(prev => (prev === text ? `${text} ` : text));
+  };
+
+  return [regionRef, announce];
+};
+
+/**
+ * SidebarOrganizer composes category sections, drag logic, and persistence state.
+ */
+export const SidebarOrganizer: React.FC<SidebarOrganizerProps> = ({
+  collapsed,
+  activeMode,
+  onSelectMode,
+  iconMap,
+  labels,
+}) => {
+  const { state, dispatch, labels: mergedLabels, persistenceError, retryPersistence } =
+    useSidebarOrganizationState(labels);
+  const tabLabels = useTabLabelMap();
+  const layoutBuckets = useLayoutBuckets(state.features, state.categories, state.collapsedCategoryIds);
+  const [liveRegionRef, announce] = useAnnouncement();
+
+  const {
+    newCategoryName,
+    newCategoryError,
+    editingCategoryId,
+    editingName,
+    editingError,
+    draggingItem,
+    featureDropTarget,
+    categoryDropTarget,
+    handleNewCategoryChange,
+    handleAddCategory,
+    beginRename,
+    commitRename,
+    handleRenameKeyDown,
+    handleRenameChange,
+    handleDeleteCategory,
+    handleFeatureKeyDown,
+    handleCategoryKeyDown,
+    handleFeatureDragStart,
+    handleCategoryDragStart,
+    dropFeature,
+    parseDragData,
+    resetDragState,
+    setFeatureDropTarget,
+    setCategoryDropTarget,
+  } = useSidebarOrganizerActions({
+    state,
+    dispatch,
+    layoutBuckets,
+    labels: mergedLabels,
+    announce,
+  });
+
+  return (
+    <div className="flex h-full flex-col" role="navigation" aria-label="Sidebar organizer">
+      {persistenceError ? (
+        <div className="mb-2 rounded-md border border-red-500/60 bg-red-500/10 p-3 text-sm text-red-500">
+          <p>{persistenceError}</p>
+          <button
+            type="button"
+            className="mt-2 rounded-md bg-red-500 px-3 py-1 text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            onClick={retryPersistence}
+          >
+            {mergedLabels.retryPersistence}
+          </button>
+        </div>
+      ) : null}
+
+      <div ref={liveRegionRef} aria-live="polite" className="sr-only" />
+
+      <div className="flex-1 overflow-y-auto pb-4" role="list">
+        {layoutBuckets.map((bucket, index) => (
+          <CategorySection
+            key={bucket.categoryId ?? 'uncategorized'}
+            bucket={bucket}
+            bucketIndex={index}
+            collapsed={collapsed}
+            activeMode={activeMode}
+            iconMap={iconMap}
+            tabLabels={tabLabels}
+            draggingItem={draggingItem}
+            featureDropTarget={featureDropTarget}
+            categoryDropTarget={categoryDropTarget}
+            mergedLabels={mergedLabels}
+            collapsedCategoryIds={state.collapsedCategoryIds}
+            editingCategoryId={editingCategoryId}
+            editingName={editingName}
+            editingError={editingError}
+            onToggleCollapse={categoryId => dispatch(toggleCategory(categoryId))}
+            onBeginRename={beginRename}
+            onDeleteCategory={handleDeleteCategory}
+            onRenameChange={handleRenameChange}
+            onRenameKeyDown={handleRenameKeyDown}
+            onRenameBlur={commitRename}
+            onFeatureKeyDown={handleFeatureKeyDown}
+            onFeatureDragStart={handleFeatureDragStart}
+            onFeatureDragEnd={resetDragState}
+            onFeatureDrop={dropFeature}
+            onCategoryDragStart={handleCategoryDragStart}
+            onCategoryDragEnd={resetDragState}
+            onCategoryKeyDown={handleCategoryKeyDown}
+            onCategoryDrop={(categoryId, targetIndex) => {
+              dispatch(moveCategory(categoryId, targetIndex));
+              const target = state.categories.find(item => item.order === targetIndex);
+              if (target) {
+                announce(mergedLabels.dropOnCategoryAnnouncement.replace('{categoryName}', target.name));
+              }
+              resetDragState();
+            }}
+            setFeatureDropTarget={setFeatureDropTarget}
+            setCategoryDropTarget={setCategoryDropTarget}
+            parseDragData={parseDragData}
+            onSelectMode={onSelectMode}
+          />
+        ))}
+        <DropZone
+          active={categoryDropTarget?.targetIndex === state.categories.length}
+          sizeClassName="h-3"
+          onDragOver={event => {
+            const data = parseDragData(event);
+            if (data?.type !== 'category') {
+              return;
+            }
+            event.preventDefault();
+            setCategoryDropTarget({ targetIndex: state.categories.length });
+          }}
+          onDrop={event => {
+            const data = parseDragData(event);
+            if (data?.type !== 'category') {
+              return;
+            }
+            event.preventDefault();
+            dispatch(moveCategory(data.id, state.categories.length));
+            resetDragState();
+          }}
+        />
+      </div>
+
+      <form onSubmit={handleAddCategory} className="mt-auto border-t border-border-color/60 px-3 py-3">
+        <label className="sr-only" htmlFor="new-category-input">
+          {mergedLabels.addCategoryLabel}
+        </label>
+        <div className="flex gap-2">
+          <input
+            id="new-category-input"
+            type="text"
+            className="flex-1 rounded-md border border-border-color bg-surface px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            placeholder={mergedLabels.addCategoryPlaceholder}
+            value={newCategoryName}
+            onChange={handleNewCategoryChange}
+          />
+          <button
+            type="submit"
+            className="rounded-md bg-primary px-3 py-1 text-sm font-semibold text-white hover:bg-primary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          >
+            {mergedLabels.addCategoryButton}
+          </button>
+        </div>
+        {newCategoryError ? <p className="mt-1 text-xs text-red-500">{newCategoryError}</p> : null}
+      </form>
+    </div>
+  );
+};

--- a/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
+++ b/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
@@ -178,15 +178,26 @@ export const SidebarOrganizer: React.FC<SidebarOrganizerProps> = ({
             active={categoryDropTarget?.targetIndex === state.categories.length}
             sizeClassName="h-3"
             onDragOver={event => {
-              const data = parseDragData(event);
-              if (data?.type !== 'category') {
-                return;
+              if (draggingItem?.type !== 'category') {
+                const data = parseDragData(event);
+                if (data?.type !== 'category') {
+                  return;
+                }
               }
               event.preventDefault();
+              if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'move';
+              }
               setCategoryDropTarget({ targetIndex: state.categories.length });
             }}
+            onDragLeave={() => {
+              setCategoryDropTarget(prev =>
+                prev?.targetIndex === state.categories.length ? null : prev,
+              );
+            }}
             onDrop={event => {
-              const data = parseDragData(event);
+              const data =
+                draggingItem?.type === 'category' ? draggingItem : parseDragData(event);
               if (data?.type !== 'category') {
                 return;
               }

--- a/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
+++ b/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
@@ -73,18 +73,17 @@ export const SidebarOrganizer: React.FC<SidebarOrganizerProps> = ({
   const [liveRegionRef, announce] = useAnnouncement();
 
   const {
-    newCategoryName,
-    newCategoryError,
     editingCategoryId,
     editingName,
     editingError,
+    isCreatingCategory,
     draggingItem,
     featureDropTarget,
     categoryDropTarget,
-    handleNewCategoryChange,
     handleAddCategory,
     beginRename,
     commitRename,
+    cancelRename,
     handleRenameKeyDown,
     handleRenameChange,
     handleDeleteCategory,
@@ -104,6 +103,13 @@ export const SidebarOrganizer: React.FC<SidebarOrganizerProps> = ({
     labels: mergedLabels,
     announce,
   });
+
+  useEffect(() => {
+    if (collapsed) {
+      cancelRename();
+      resetDragState();
+    }
+  }, [cancelRename, collapsed, resetDragState]);
 
   return (
     <div className="flex h-full flex-col" role="navigation" aria-label="Sidebar organizer">
@@ -167,51 +173,47 @@ export const SidebarOrganizer: React.FC<SidebarOrganizerProps> = ({
             onSelectMode={onSelectMode}
           />
         ))}
-        <DropZone
-          active={categoryDropTarget?.targetIndex === state.categories.length}
-          sizeClassName="h-3"
-          onDragOver={event => {
-            const data = parseDragData(event);
-            if (data?.type !== 'category') {
-              return;
-            }
-            event.preventDefault();
-            setCategoryDropTarget({ targetIndex: state.categories.length });
-          }}
-          onDrop={event => {
-            const data = parseDragData(event);
-            if (data?.type !== 'category') {
-              return;
-            }
-            event.preventDefault();
-            dispatch(moveCategory(data.id, state.categories.length));
-            resetDragState();
-          }}
-        />
+        {!collapsed ? (
+          <DropZone
+            active={categoryDropTarget?.targetIndex === state.categories.length}
+            sizeClassName="h-3"
+            onDragOver={event => {
+              const data = parseDragData(event);
+              if (data?.type !== 'category') {
+                return;
+              }
+              event.preventDefault();
+              setCategoryDropTarget({ targetIndex: state.categories.length });
+            }}
+            onDrop={event => {
+              const data = parseDragData(event);
+              if (data?.type !== 'category') {
+                return;
+              }
+              event.preventDefault();
+              dispatch(moveCategory(data.id, state.categories.length));
+              resetDragState();
+            }}
+          />
+        ) : null}
       </div>
 
-      <form onSubmit={handleAddCategory} className="mt-auto border-t border-border-color/60 px-3 py-3">
-        <label className="sr-only" htmlFor="new-category-input">
-          {mergedLabels.addCategoryLabel}
-        </label>
-        <div className="flex gap-2">
-          <input
-            id="new-category-input"
-            type="text"
-            className="flex-1 rounded-md border border-border-color bg-surface px-2 py-1 text-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            placeholder={mergedLabels.addCategoryPlaceholder}
-            value={newCategoryName}
-            onChange={handleNewCategoryChange}
-          />
+      {!collapsed ? (
+        <div className="mt-auto border-t border-border-color/60 px-3 py-3">
           <button
-            type="submit"
-            className="rounded-md bg-primary px-3 py-1 text-sm font-semibold text-white hover:bg-primary/80 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            type="button"
+            onClick={handleAddCategory}
+            className="flex w-full items-center justify-center gap-2 rounded-md border border-dashed border-border-color/70 bg-secondary/50 px-3 py-2 text-sm font-semibold text-text-secondary transition-colors hover:border-border-color hover:text-text-primary focus:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-60"
+            aria-label={mergedLabels.addCategoryLabel}
+            disabled={editingCategoryId !== null || isCreatingCategory}
           >
-            {mergedLabels.addCategoryButton}
+            <span className="text-base" aria-hidden="true">
+              +
+            </span>
+            <span>{mergedLabels.addCategoryButton}</span>
           </button>
         </div>
-        {newCategoryError ? <p className="mt-1 text-xs text-red-500">{newCategoryError}</p> : null}
-      </form>
+      ) : null}
     </div>
   );
 };

--- a/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
+++ b/components/layouts/sidebarOrganizer/SidebarOrganizer.tsx
@@ -177,6 +177,7 @@ export const SidebarOrganizer: React.FC<SidebarOrganizerProps> = ({
           <DropZone
             active={categoryDropTarget?.targetIndex === state.categories.length}
             sizeClassName="h-3"
+            className="px-2"
             onDragOver={event => {
               if (draggingItem?.type !== 'category') {
                 const data = parseDragData(event);

--- a/components/layouts/sidebarOrganizer/actions.ts
+++ b/components/layouts/sidebarOrganizer/actions.ts
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Action creators for the sidebar organization reducer.
+ * Each action is a pure object describing a state transition and therefore carries no timeout or retry logic.
+ */
+
+import type { SidebarOrganizationAction, SidebarOrganizationState } from './types';
+
+/**
+ * Creates an action that appends a new category.
+ */
+export const addCategory = (id: string, name: string): SidebarOrganizationAction => ({
+  type: 'ADD_CATEGORY',
+  payload: { id, name },
+});
+
+/**
+ * Produces an action that merges two categories. All features from the source flow into the target.
+ */
+export const mergeCategories = (sourceId: string, targetId: string): SidebarOrganizationAction => ({
+  type: 'MERGE_CATEGORIES',
+  payload: { sourceId, targetId },
+});
+
+/**
+ * Generates an action for renaming a category.
+ */
+export const renameCategory = (id: string, name: string): SidebarOrganizationAction => ({
+  type: 'RENAME_CATEGORY',
+  payload: { id, name },
+});
+
+/**
+ * Constructs an action that removes a category without deleting its features.
+ */
+export const deleteCategory = (id: string): SidebarOrganizationAction => ({
+  type: 'DELETE_CATEGORY',
+  payload: { id },
+});
+
+/**
+ * Reorders a category relative to its siblings.
+ */
+export const moveCategory = (id: string, targetIndex: number): SidebarOrganizationAction => ({
+  type: 'MOVE_CATEGORY',
+  payload: { id, targetIndex },
+});
+
+/**
+ * Moves a feature into a new category or reorders it within the same category.
+ */
+export const moveFeature = (
+  featureId: string,
+  targetCategoryId: string | null,
+  targetIndex: number,
+): SidebarOrganizationAction => ({
+  type: 'MOVE_FEATURE',
+  payload: { featureId, targetCategoryId, targetIndex },
+});
+
+/**
+ * Toggles the collapsed state for a category panel.
+ */
+export const toggleCategory = (id: string): SidebarOrganizationAction => ({
+  type: 'TOGGLE_CATEGORY',
+  payload: { id },
+});
+
+/**
+ * Hydrates the state tree with an externally loaded snapshot.
+ */
+export const hydrateState = (snapshot: SidebarOrganizationState): SidebarOrganizationAction => ({
+  type: 'HYDRATE',
+  payload: snapshot,
+});

--- a/components/layouts/sidebarOrganizer/constants.ts
+++ b/components/layouts/sidebarOrganizer/constants.ts
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Houses constants and helper data structures used by the sidebar organization module.
+ * The module depends solely on browser storage APIs; it does not invoke external services.
+ */
+
+import type { Mode } from '../../../types';
+import { TABS } from '../../../constants/uiConstants';
+import type {
+  SidebarCategory,
+  SidebarFeature,
+  SidebarOrganizerLabels,
+  SidebarOrganizationState,
+} from './types';
+
+/**
+ * Storage key for persisting sidebar organization metadata.
+ */
+export const SIDEBAR_ORGANIZATION_STORAGE_KEY = 'ai_content_suite_sidebar_organization_v1';
+
+/**
+ * Blueprint of initial categories reflecting the legacy static sidebar layout.
+ */
+export const DEFAULT_CATEGORIES: SidebarCategory[] = [
+  { id: 'workspace', name: 'Workspace', order: 0 },
+  { id: 'orchestration', name: 'Orchestration', order: 1 },
+  { id: 'interactive', name: 'Interactive', order: 2 },
+];
+
+/**
+ * Default uncategorized order baseline. Values lower than this float to the top of the uncategorized list.
+ */
+const UNCATEGORIZED_BASE_ORDER = -1_000_000;
+
+/**
+ * Generates deterministic default feature entries derived from the global tab registry.
+ */
+export const buildDefaultFeatures = (): SidebarFeature[] =>
+  TABS.map((tab, index): SidebarFeature => ({
+    id: tab.id,
+    mode: tab.id as Mode,
+    name: tab.label,
+    categoryId:
+      index <= 5
+        ? 'workspace'
+        : index <= 8
+          ? 'orchestration'
+          : index === 9
+            ? 'interactive'
+            : null,
+    order: index,
+  }));
+
+/**
+ * Default persisted state used when no prior user customization exists.
+ */
+export const buildDefaultSidebarState = (): SidebarOrganizationState => ({
+  categories: DEFAULT_CATEGORIES.map(category => ({ ...category })),
+  features: buildDefaultFeatures(),
+  collapsedCategoryIds: [],
+  lastUpdated: new Date().toISOString(),
+});
+
+/**
+ * Localizable strings surfaced throughout the organizer. Consumers may override individual entries.
+ */
+export const DEFAULT_LABELS: SidebarOrganizerLabels = {
+  addCategoryLabel: 'Add a new category',
+  addCategoryPlaceholder: 'Enter category name',
+  addCategoryButton: 'Add',
+  renameCategory: 'Rename category',
+  deleteCategory: 'Delete category',
+  emptyCategoryError: 'Category name cannot be empty.',
+  persistenceError: 'We were unable to save your sidebar changes. Your previous layout has been restored.',
+  retryPersistence: 'Retry save',
+  featureGrabAnnouncement: 'Started moving feature.',
+  categoryGrabAnnouncement: 'Started moving category.',
+  dropOnCategoryAnnouncement: 'Moved into category {categoryName}.',
+  dropBetweenFeaturesAnnouncement: 'Placed before {featureName}.',
+  uncategorizedAnnouncement: 'Moved to the uncategorized area.',
+};
+
+/**
+ * Produces a deterministic identifier for newly created categories.
+ */
+export const createCategoryId = (): string =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `category-${Math.random().toString(36).slice(2, 10)}`;
+
+/**
+ * Calculates an order index that ensures uncategorized items surface at the top after a merge.
+ */
+export const computeUncategorizedInsertionOrder = (currentMin: number, offset: number): number =>
+  UNCATEGORIZED_BASE_ORDER + currentMin - offset;

--- a/components/layouts/sidebarOrganizer/constants.ts
+++ b/components/layouts/sidebarOrganizer/constants.ts
@@ -65,11 +65,11 @@ export const buildDefaultSidebarState = (): SidebarOrganizationState => ({
  */
 export const DEFAULT_LABELS: SidebarOrganizerLabels = {
   addCategoryLabel: 'Add a new category',
-  addCategoryPlaceholder: 'Enter category name',
-  addCategoryButton: 'Add',
+  addCategoryButton: 'Add category',
   renameCategory: 'Rename category',
   deleteCategory: 'Delete category',
   emptyCategoryError: 'Category name cannot be empty.',
+  newCategoryDefaultName: 'New category',
   persistenceError: 'We were unable to save your sidebar changes. Your previous layout has been restored.',
   retryPersistence: 'Retry save',
   featureGrabAnnouncement: 'Started moving feature.',

--- a/components/layouts/sidebarOrganizer/dragTypes.ts
+++ b/components/layouts/sidebarOrganizer/dragTypes.ts
@@ -6,6 +6,10 @@ export type DraggingItem =
   | { type: 'feature'; id: string; viaKeyboard: boolean }
   | { type: 'category'; id: string; viaKeyboard: boolean };
 
-export type FeatureDropTarget = { categoryId: string | null; index: number } | null;
+export type FeatureDropContext = 'item' | 'zone' | 'header';
+
+export type FeatureDropTarget =
+  | { categoryId: string | null; index: number; context?: FeatureDropContext }
+  | null;
 
 export type CategoryDropTarget = { targetIndex: number } | null;

--- a/components/layouts/sidebarOrganizer/dragTypes.ts
+++ b/components/layouts/sidebarOrganizer/dragTypes.ts
@@ -6,7 +6,7 @@ export type DraggingItem =
   | { type: 'feature'; id: string; viaKeyboard: boolean }
   | { type: 'category'; id: string; viaKeyboard: boolean };
 
-export type FeatureDropContext = 'item' | 'zone' | 'header';
+export type FeatureDropContext = 'before-item' | 'after-item' | 'zone' | 'header';
 
 export type FeatureDropTarget =
   | { categoryId: string | null; index: number; context?: FeatureDropContext }

--- a/components/layouts/sidebarOrganizer/dragTypes.ts
+++ b/components/layouts/sidebarOrganizer/dragTypes.ts
@@ -1,0 +1,11 @@
+/**
+ * @fileoverview Shared drag-and-drop type definitions for the sidebar organizer module.
+ */
+
+export type DraggingItem =
+  | { type: 'feature'; id: string; viaKeyboard: boolean }
+  | { type: 'category'; id: string; viaKeyboard: boolean };
+
+export type FeatureDropTarget = { categoryId: string | null; index: number } | null;
+
+export type CategoryDropTarget = { targetIndex: number } | null;

--- a/components/layouts/sidebarOrganizer/reducer.ts
+++ b/components/layouts/sidebarOrganizer/reducer.ts
@@ -1,0 +1,195 @@
+/**
+ * @fileoverview Implements the reducer that orchestrates sidebar organization state transitions.
+ * Reducer operations are synchronous and operate entirely in-memory, therefore they do not require timeout handling.
+ */
+
+import type {
+  SidebarFeature,
+  SidebarOrganizationAction,
+  SidebarOrganizationState,
+} from './types';
+
+/**
+ * Ensures order indexes are contiguous and start at zero.
+ */
+const normalizeOrder = <T extends { order: number }>(items: T[]): T[] =>
+  items
+    .slice()
+    .sort((a, b) => a.order - b.order)
+    .map((item, index) => ({ ...item, order: index }));
+
+/**
+ * Applies an updated timestamp to the provided state payload.
+ */
+const withTimestamp = (state: Omit<SidebarOrganizationState, 'lastUpdated'>): SidebarOrganizationState => ({
+  ...state,
+  lastUpdated: new Date().toISOString(),
+});
+
+/**
+ * Buckets features by category id for easier manipulation.
+ */
+const bucketFeatures = (
+  features: SidebarFeature[],
+): Map<string | null, SidebarFeature[]> => {
+  const buckets = new Map<string | null, SidebarFeature[]>();
+  const sorted = features.slice().sort((a, b) => a.order - b.order);
+  for (const feature of sorted) {
+    const key = feature.categoryId ?? null;
+    const collection = buckets.get(key) ?? [];
+    collection.push({ ...feature });
+    buckets.set(key, collection);
+  }
+  return buckets;
+};
+
+/**
+ * Flattens buckets back into a feature array while normalizing order indexes per bucket.
+ */
+const flattenBuckets = (buckets: Map<string | null, SidebarFeature[]>): SidebarFeature[] => {
+  const flattened: SidebarFeature[] = [];
+  buckets.forEach((bucket, categoryId) => {
+    bucket.forEach((feature, index) => {
+      flattened.push({ ...feature, categoryId, order: index });
+    });
+  });
+  return flattened;
+};
+
+/**
+ * Inserts moved features at the start of the uncategorized bucket while preserving their relative order.
+ */
+const prependToUncategorized = (
+  buckets: Map<string | null, SidebarFeature[]>,
+  moved: SidebarFeature[],
+): void => {
+  const uncategorized = buckets.get(null) ?? [];
+  const existing = uncategorized.filter(feature => !moved.some(item => item.id === feature.id));
+  buckets.set(null, [...moved.map(item => ({ ...item, categoryId: null })), ...existing]);
+};
+
+/**
+ * Core reducer handling every supported organization action.
+ */
+export const sidebarOrganizationReducer = (
+  state: SidebarOrganizationState,
+  action: SidebarOrganizationAction,
+): SidebarOrganizationState => {
+  switch (action.type) {
+    case 'ADD_CATEGORY': {
+      const order = state.categories.reduce((max, category) => Math.max(max, category.order), -1) + 1;
+      return withTimestamp({
+        ...state,
+        categories: [...state.categories, { id: action.payload.id, name: action.payload.name, order }],
+      });
+    }
+    case 'MERGE_CATEGORIES': {
+      const { sourceId, targetId } = action.payload;
+      if (sourceId === targetId) {
+        return state;
+      }
+      const buckets = bucketFeatures(state.features);
+      const sourceBucket = buckets.get(sourceId) ?? [];
+      if (targetId === null) {
+        prependToUncategorized(buckets, sourceBucket);
+      } else {
+        const targetBucket = buckets.get(targetId) ?? [];
+        buckets.set(targetId, [...targetBucket, ...sourceBucket.map(feature => ({ ...feature, categoryId: targetId }))]);
+      }
+      buckets.delete(sourceId);
+      const categories = normalizeOrder(state.categories.filter(category => category.id !== sourceId));
+      return withTimestamp({
+        ...state,
+        categories,
+        features: flattenBuckets(buckets),
+        collapsedCategoryIds: state.collapsedCategoryIds.filter(id => id !== sourceId),
+      });
+    }
+    case 'RENAME_CATEGORY': {
+      const { id, name } = action.payload;
+      return withTimestamp({
+        ...state,
+        categories: state.categories.map(category =>
+          category.id === id
+            ? {
+                ...category,
+                name,
+              }
+            : category,
+        ),
+      });
+    }
+    case 'DELETE_CATEGORY': {
+      const { id } = action.payload;
+      const buckets = bucketFeatures(state.features);
+      const moved = buckets.get(id) ?? [];
+      prependToUncategorized(buckets, moved);
+      buckets.delete(id);
+      return withTimestamp({
+        ...state,
+        categories: normalizeOrder(state.categories.filter(category => category.id !== id)),
+        features: flattenBuckets(buckets),
+        collapsedCategoryIds: state.collapsedCategoryIds.filter(categoryId => categoryId !== id),
+      });
+    }
+    case 'MOVE_CATEGORY': {
+      const { id, targetIndex } = action.payload;
+      const sorted = normalizeOrder(state.categories);
+      const currentIndex = sorted.findIndex(category => category.id === id);
+      if (currentIndex === -1) {
+        return state;
+      }
+      const updated = sorted.slice();
+      const [removed] = updated.splice(currentIndex, 1);
+      const boundedIndex = Math.max(0, Math.min(targetIndex, updated.length));
+      updated.splice(boundedIndex, 0, removed);
+      return withTimestamp({
+        ...state,
+        categories: updated.map((category, index) => ({ ...category, order: index })),
+      });
+    }
+    case 'MOVE_FEATURE': {
+      const { featureId, targetCategoryId, targetIndex } = action.payload;
+      const buckets = bucketFeatures(state.features);
+      const sourceKey = Array.from(buckets.keys()).find(key =>
+        (buckets.get(key) ?? []).some(feature => feature.id === featureId),
+      );
+      if (typeof sourceKey === 'undefined') {
+        return state;
+      }
+      const sourceBucket = buckets.get(sourceKey) ?? [];
+      const movingIndex = sourceBucket.findIndex(feature => feature.id === featureId);
+      if (movingIndex === -1) {
+        return state;
+      }
+      const [movingFeature] = sourceBucket.splice(movingIndex, 1);
+      buckets.set(sourceKey, sourceBucket);
+
+      const destinationKey = targetCategoryId ?? null;
+      const destinationBucket = buckets.get(destinationKey) ?? [];
+      const boundedIndex = Math.max(0, Math.min(targetIndex, destinationBucket.length));
+      destinationBucket.splice(boundedIndex, 0, { ...movingFeature, categoryId: destinationKey });
+      buckets.set(destinationKey, destinationBucket);
+
+      return withTimestamp({
+        ...state,
+        features: flattenBuckets(buckets),
+      });
+    }
+    case 'TOGGLE_CATEGORY': {
+      const { id } = action.payload;
+      const isCollapsed = state.collapsedCategoryIds.includes(id);
+      return withTimestamp({
+        ...state,
+        collapsedCategoryIds: isCollapsed
+          ? state.collapsedCategoryIds.filter(categoryId => categoryId !== id)
+          : [...state.collapsedCategoryIds, id],
+      });
+    }
+    case 'HYDRATE': {
+      return { ...action.payload };
+    }
+    default:
+      return state;
+  }
+};

--- a/components/layouts/sidebarOrganizer/types.ts
+++ b/components/layouts/sidebarOrganizer/types.ts
@@ -88,9 +88,7 @@ export type ModeIconMap = Record<Mode, ElementType>;
 export interface SidebarOrganizerLabels {
   /** Label for the add-category text input. */
   addCategoryLabel: string;
-  /** Placeholder text for the add-category input. */
-  addCategoryPlaceholder: string;
-  /** Text for the add button. */
+  /** Text for the add-category button. */
   addCategoryButton: string;
   /** Accessible label for the rename control. */
   renameCategory: string;
@@ -98,6 +96,8 @@ export interface SidebarOrganizerLabels {
   deleteCategory: string;
   /** Inline validation message for blank category names. */
   emptyCategoryError: string;
+  /** Default name applied when creating a new category before it is renamed. */
+  newCategoryDefaultName: string;
   /** Message shown when persistence fails. */
   persistenceError: string;
   /** Button label that retries persistence. */

--- a/components/layouts/sidebarOrganizer/types.ts
+++ b/components/layouts/sidebarOrganizer/types.ts
@@ -1,0 +1,120 @@
+/**
+ * @fileoverview Defines strongly typed contracts used by the sidebar organization module.
+ * The module manages drag-and-drop organization of feature categories while remaining UI-framework agnostic.
+ * It uses browser `localStorage` for persistence and does not perform network requests, so no timeout strategy is required.
+ */
+
+import type { ElementType } from 'react';
+import type { Mode } from '../../../types';
+
+/**
+ * Describes a sidebar category that groups related feature shortcuts.
+ */
+export interface SidebarCategory {
+  /** Unique identifier for the category. */
+  id: string;
+  /** Visible category label displayed to the user. */
+  name: string;
+  /**
+   * Order index used for deterministic rendering. Lower values render higher in the list.
+   * Values are persisted so categories maintain their position across sessions.
+   */
+  order: number;
+}
+
+/**
+ * Represents a single feature entry within the sidebar.
+ */
+export interface SidebarFeature {
+  /** Identifier that also maps to the workspace mode. */
+  id: string;
+  /** Workspace mode associated with this feature. */
+  mode: Mode;
+  /** Localized label rendered next to the feature icon. */
+  name: string;
+  /** Category identifier or null when the feature is uncategorized. */
+  categoryId: string | null;
+  /**
+   * Order value used to position the feature within its category.
+   * Ordering is relative per category.
+   */
+  order: number;
+}
+
+/**
+ * Captures persisted sidebar organization state.
+ */
+export interface SidebarOrganizationState {
+  /** Ordered categories excluding the implicit uncategorized bucket. */
+  categories: SidebarCategory[];
+  /** All feature entries regardless of assignment. */
+  features: SidebarFeature[];
+  /**
+   * Categories that are currently collapsed. Collapsed state is persisted and scoped per category id.
+   */
+  collapsedCategoryIds: string[];
+  /** ISO timestamp for the last successful state mutation. */
+  lastUpdated: string;
+}
+
+/**
+ * Enumerates supported reducer actions. Consumers typically create them through helper functions.
+ */
+export type SidebarOrganizationAction =
+  | { type: 'ADD_CATEGORY'; payload: { id: string; name: string } }
+  | { type: 'MERGE_CATEGORIES'; payload: { sourceId: string; targetId: string } }
+  | { type: 'RENAME_CATEGORY'; payload: { id: string; name: string } }
+  | { type: 'DELETE_CATEGORY'; payload: { id: string } }
+  | { type: 'MOVE_CATEGORY'; payload: { id: string; targetIndex: number } }
+  | {
+      type: 'MOVE_FEATURE';
+      payload: {
+        featureId: string;
+        targetCategoryId: string | null;
+        targetIndex: number;
+      };
+    }
+  | { type: 'TOGGLE_CATEGORY'; payload: { id: string } }
+  | { type: 'HYDRATE'; payload: SidebarOrganizationState };
+
+/**
+ * Maps workspace modes to React components responsible for rendering their icons.
+ */
+export type ModeIconMap = Record<Mode, ElementType>;
+
+/**
+ * Localizable text snippets used throughout the organizer UI.
+ */
+export interface SidebarOrganizerLabels {
+  /** Label for the add-category text input. */
+  addCategoryLabel: string;
+  /** Placeholder text for the add-category input. */
+  addCategoryPlaceholder: string;
+  /** Text for the add button. */
+  addCategoryButton: string;
+  /** Accessible label for the rename control. */
+  renameCategory: string;
+  /** Accessible label for the delete control. */
+  deleteCategory: string;
+  /** Inline validation message for blank category names. */
+  emptyCategoryError: string;
+  /** Message shown when persistence fails. */
+  persistenceError: string;
+  /** Button label that retries persistence. */
+  retryPersistence: string;
+  /** Announcement when a feature drag starts. */
+  featureGrabAnnouncement: string;
+  /** Announcement when a category drag starts. */
+  categoryGrabAnnouncement: string;
+  /** Announcement template when dropping onto a category. */
+  dropOnCategoryAnnouncement: string;
+  /** Announcement template when dropping between features. */
+  dropBetweenFeaturesAnnouncement: string;
+  /** Announcement when moving to uncategorized. */
+  uncategorizedAnnouncement: string;
+}
+
+/**
+ * Signature for broadcasting updates to an aria-live region.
+ */
+export type AnnounceFn = (message: string) => void;

--- a/components/layouts/sidebarOrganizer/useLayoutBuckets.ts
+++ b/components/layouts/sidebarOrganizer/useLayoutBuckets.ts
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Hook that builds memoized layout buckets combining categories and their feature lists.
+ * The hook operates purely on in-memory collections and requires no timeout configuration.
+ */
+
+import { useMemo } from 'react';
+import type { SidebarFeature } from './types';
+import type { SidebarOrganizationState } from './types';
+
+/**
+ * Describes the shape of a rendered category bucket.
+ */
+export interface LayoutBucket {
+  /** Null for the uncategorized bucket, otherwise the category id. */
+  categoryId: string | null;
+  /** Optional visible title. */
+  title: string | null;
+  /** Feature entries assigned to the bucket. */
+  features: SidebarFeature[];
+  /** Whether the bucket is currently collapsed. */
+  isCollapsible: boolean;
+}
+
+/**
+ * Memoizes a union of uncategorized and categorized feature buckets for rendering convenience.
+ */
+export const useLayoutBuckets = (
+  features: SidebarFeature[],
+  categories: SidebarOrganizationState['categories'],
+  collapsedCategoryIds: string[],
+): LayoutBucket[] =>
+  useMemo(() => {
+    const categoryLookup = new Map(categories.map(category => [category.id, category]));
+    const buckets = new Map<string | null, SidebarFeature[]>();
+    const sortedFeatures = features.slice().sort((a, b) => a.order - b.order);
+    for (const feature of sortedFeatures) {
+      const key = feature.categoryId ?? null;
+      const group = buckets.get(key) ?? [];
+      group.push(feature);
+      buckets.set(key, group);
+    }
+
+    const orderedCategories = categories.slice().sort((a, b) => a.order - b.order);
+    const layout: LayoutBucket[] = [
+      {
+        categoryId: null,
+        title: null,
+        features: buckets.get(null) ?? [],
+        isCollapsible: false,
+      },
+    ];
+
+    orderedCategories.forEach(category => {
+      layout.push({
+        categoryId: category.id,
+        title: categoryLookup.get(category.id)?.name ?? category.name,
+        features: buckets.get(category.id) ?? [],
+        isCollapsible: collapsedCategoryIds.includes(category.id),
+      });
+    });
+
+    return layout;
+  }, [categories, collapsedCategoryIds, features]);

--- a/components/layouts/sidebarOrganizer/useSidebarOrganizationState.ts
+++ b/components/layouts/sidebarOrganizer/useSidebarOrganizationState.ts
@@ -1,0 +1,184 @@
+/**
+ * @fileoverview React hook responsible for orchestrating sidebar organization state and persistence.
+ * The hook reads from and writes to `localStorage` and therefore has no reliance on remote services or custom timeouts.
+ */
+
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { DEFAULT_LABELS, SIDEBAR_ORGANIZATION_STORAGE_KEY, buildDefaultSidebarState } from './constants';
+import { sidebarOrganizationReducer } from './reducer';
+import type {
+  SidebarFeature,
+  SidebarOrganizerLabels,
+  SidebarOrganizationAction,
+  SidebarOrganizationState,
+} from './types';
+
+/**
+ * Normalizes category ordering while preserving insertion order for existing items.
+ */
+const normalizeCategories = (categories: SidebarOrganizationState['categories']) =>
+  categories
+    .slice()
+    .sort((a, b) => a.order - b.order)
+    .map((category, index) => ({ ...category, order: index }));
+
+/**
+ * Normalizes feature ordering per category.
+ */
+const normalizeFeatures = (features: SidebarFeature[]): SidebarFeature[] => {
+  const buckets = new Map<string | null, SidebarFeature[]>();
+  for (const feature of features) {
+    const key = feature.categoryId ?? null;
+    const bucket = buckets.get(key) ?? [];
+    bucket.push(feature);
+    buckets.set(key, bucket);
+  }
+
+  const ordered: SidebarFeature[] = [];
+  buckets.forEach((bucket, categoryId) => {
+    bucket
+      .slice()
+      .sort((a, b) => a.order - b.order)
+      .forEach((feature, index) => {
+        ordered.push({ ...feature, categoryId, order: index });
+      });
+  });
+  return ordered;
+};
+
+/**
+ * Safely reads an existing snapshot from localStorage.
+ */
+const readStoredState = (): SidebarOrganizationState | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  const raw = window.localStorage.getItem(SIDEBAR_ORGANIZATION_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as SidebarOrganizationState;
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse stored sidebar organization state.', error);
+    return null;
+  }
+};
+
+/**
+ * Builds a resilient initial state by merging stored data with defaults.
+ */
+const buildInitialState = (): SidebarOrganizationState => {
+  const defaults = buildDefaultSidebarState();
+  const stored = readStoredState();
+  if (!stored) {
+    return defaults;
+  }
+
+  const storedCategories = Array.isArray(stored.categories) ? stored.categories : [];
+  const storedFeatures = Array.isArray(stored.features) ? stored.features : [];
+
+  const mergedCategories = normalizeCategories([
+    ...storedCategories,
+    ...defaults.categories.filter(category =>
+      storedCategories.every(existing => existing.id !== category.id),
+    ),
+  ]);
+  const validCategoryIds = new Set(mergedCategories.map(category => category.id));
+
+  const mergedFeatures = normalizeFeatures([
+    ...storedFeatures.map(feature =>
+      feature.categoryId && !validCategoryIds.has(feature.categoryId)
+        ? { ...feature, categoryId: null }
+        : feature,
+    ),
+    ...defaults.features.filter(feature => storedFeatures.every(item => item.id !== feature.id)),
+  ]);
+
+  return {
+    categories: mergedCategories,
+    features: mergedFeatures,
+    collapsedCategoryIds: stored.collapsedCategoryIds?.filter(id => validCategoryIds.has(id)) ?? [],
+    lastUpdated: stored.lastUpdated ?? new Date().toISOString(),
+  };
+};
+
+/**
+ * Persists state to localStorage.
+ */
+const persistState = (state: SidebarOrganizationState): void => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  window.localStorage.setItem(SIDEBAR_ORGANIZATION_STORAGE_KEY, JSON.stringify(state));
+};
+
+/**
+ * Hook return signature describing state and helper utilities.
+ */
+export interface SidebarOrganizationHook {
+  /** Current sidebar organization snapshot. */
+  state: SidebarOrganizationState;
+  /** Dispatches an action to mutate the state. */
+  dispatch: (action: SidebarOrganizationAction) => void;
+  /** Optional localized labels. */
+  labels: SidebarOrganizerLabels;
+  /** Error message shown when persistence fails. */
+  persistenceError: string | null;
+  /** Retries persisting the current state. */
+  retryPersistence: () => void;
+}
+
+/**
+ * React hook that centralizes sidebar organization state, persistence, and localization.
+ */
+export const useSidebarOrganizationState = (
+  labels: Partial<SidebarOrganizerLabels> | undefined = undefined,
+): SidebarOrganizationHook => {
+  const mergedLabels = useMemo(() => ({ ...DEFAULT_LABELS, ...labels }), [labels]);
+  const [state, setState] = useState<SidebarOrganizationState>(() => buildInitialState());
+  const stateRef = useRef(state);
+  const [persistenceError, setPersistenceError] = useState<string | null>(null);
+
+  stateRef.current = state;
+
+  const dispatch = useCallback(
+    (action: SidebarOrganizationAction) => {
+      setState(prev => {
+        const next = sidebarOrganizationReducer(prev, action);
+        try {
+          persistState(next);
+          setPersistenceError(null);
+          return next;
+        } catch (error) {
+          console.error('Unable to persist sidebar organization state.', error);
+          setPersistenceError(mergedLabels.persistenceError);
+          return prev;
+        }
+      });
+    },
+    [mergedLabels.persistenceError],
+  );
+
+  const retryPersistence = useCallback(() => {
+    try {
+      persistState(stateRef.current);
+      setPersistenceError(null);
+    } catch (error) {
+      console.error('Retrying sidebar organization persistence failed.', error);
+      setPersistenceError(mergedLabels.persistenceError);
+    }
+  }, [mergedLabels.persistenceError]);
+
+  return {
+    state,
+    dispatch,
+    labels: mergedLabels,
+    persistenceError,
+    retryPersistence,
+  };
+};

--- a/components/layouts/sidebarOrganizer/useSidebarOrganizerActions.ts
+++ b/components/layouts/sidebarOrganizer/useSidebarOrganizerActions.ts
@@ -1,0 +1,434 @@
+/**
+ * @fileoverview Hook encapsulating all interactive handlers for the sidebar organizer component.
+ * The hook manages local UI state such as rename fields, drag indicators, and persistence events.
+ */
+
+import { useCallback, useState } from 'react';
+import type { ChangeEvent, DragEvent, FormEvent, KeyboardEvent, Dispatch, SetStateAction } from 'react';
+import type { SidebarOrganizerLabels, SidebarOrganizationState } from './types';
+import type { SidebarOrganizationAction } from './types';
+import type { LayoutBucket } from './useLayoutBuckets';
+import {
+  addCategory,
+  deleteCategory,
+  mergeCategories,
+  moveCategory,
+  moveFeature,
+  renameCategory,
+} from './actions';
+import { createCategoryId } from './constants';
+import type { DraggingItem, FeatureDropTarget, CategoryDropTarget } from './dragTypes';
+
+const DRAG_DATA_MIME = 'application/x-sidebar-item';
+
+interface UseSidebarOrganizerActionsParams {
+  state: SidebarOrganizationState;
+  dispatch: Dispatch<SidebarOrganizationAction>;
+  layoutBuckets: LayoutBucket[];
+  labels: SidebarOrganizerLabels;
+  announce: (message: string) => void;
+}
+
+interface UseSidebarOrganizerActionsResult {
+  newCategoryName: string;
+  newCategoryError: string | null;
+  editingCategoryId: string | null;
+  editingName: string;
+  editingError: string | null;
+  draggingItem: DraggingItem | null;
+  featureDropTarget: FeatureDropTarget;
+  categoryDropTarget: CategoryDropTarget;
+  handleNewCategoryChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleAddCategory: (event: FormEvent<HTMLFormElement>) => void;
+  beginRename: (categoryId: string, currentName: string) => void;
+  commitRename: () => void;
+  cancelRename: () => void;
+  handleRenameKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
+  handleRenameChange: (categoryId: string, value: string) => void;
+  handleDeleteCategory: (categoryId: string) => void;
+  handleFeatureKeyDown: (event: KeyboardEvent<HTMLButtonElement>, featureId: string) => void;
+  handleCategoryKeyDown: (event: KeyboardEvent<HTMLDivElement>, categoryId: string) => void;
+  handleFeatureDragStart: (event: DragEvent<HTMLButtonElement>, featureId: string) => void;
+  handleCategoryDragStart: (event: DragEvent<HTMLDivElement>, categoryId: string) => void;
+  dropFeature: (featureId: string, categoryId: string | null, index: number) => void;
+  parseDragData: (event: DragEvent) => DraggingItem | null;
+  resetDragState: () => void;
+  setFeatureDropTarget: Dispatch<SetStateAction<FeatureDropTarget>>;
+  setCategoryDropTarget: Dispatch<SetStateAction<CategoryDropTarget>>;
+}
+
+/**
+ * Provides all stateful handlers required by the sidebar organizer component.
+ */
+export const useSidebarOrganizerActions = ({
+  state,
+  dispatch,
+  layoutBuckets,
+  labels,
+  announce,
+}: UseSidebarOrganizerActionsParams): UseSidebarOrganizerActionsResult => {
+  const [newCategoryName, setNewCategoryName] = useState('');
+  const [newCategoryError, setNewCategoryError] = useState<string | null>(null);
+  const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
+  const [editingName, setEditingName] = useState('');
+  const [editingError, setEditingError] = useState<string | null>(null);
+  const [draggingItem, setDraggingItem] = useState<DraggingItem | null>(null);
+  const [featureDropTarget, setFeatureDropTarget] = useState<FeatureDropTarget>(null);
+  const [categoryDropTarget, setCategoryDropTarget] = useState<CategoryDropTarget>(null);
+
+  /**
+   * Clears drag state for both features and categories.
+   */
+  const resetDragState = useCallback(() => {
+    setDraggingItem(null);
+    setFeatureDropTarget(null);
+    setCategoryDropTarget(null);
+  }, []);
+
+  /**
+   * Updates controlled input state for new category creation.
+   */
+  const handleNewCategoryChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setNewCategoryName(event.target.value);
+    setNewCategoryError(null);
+  }, []);
+
+  /**
+   * Persists a newly created category while enforcing duplicate-name merge semantics.
+   */
+  const handleAddCategory = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmed = newCategoryName.trim();
+      if (!trimmed) {
+        setNewCategoryError(labels.emptyCategoryError);
+        return;
+      }
+      const existing = state.categories.find(
+        category => category.name.toLowerCase() === trimmed.toLowerCase(),
+      );
+      const newId = createCategoryId();
+      if (existing) {
+        dispatch(addCategory(newId, trimmed));
+        dispatch(mergeCategories(newId, existing.id));
+        announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', existing.name));
+      } else {
+        dispatch(addCategory(newId, trimmed));
+        announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', trimmed));
+      }
+      setNewCategoryName('');
+      setNewCategoryError(null);
+    },
+    [announce, dispatch, labels.dropOnCategoryAnnouncement, labels.emptyCategoryError, newCategoryName, state.categories],
+  );
+
+  /**
+   * Enters rename mode for a chosen category.
+   */
+  const beginRename = useCallback((categoryId: string, currentName: string) => {
+    setEditingCategoryId(categoryId);
+    setEditingName(currentName);
+    setEditingError(null);
+  }, []);
+
+  /**
+   * Cancels rename mode without persisting modifications.
+   */
+  const cancelRename = useCallback(() => {
+    setEditingCategoryId(null);
+    setEditingName('');
+    setEditingError(null);
+  }, []);
+
+  /**
+   * Commits rename changes, merging with an existing category when names collide.
+   */
+  const commitRename = useCallback(() => {
+    if (!editingCategoryId) {
+      return;
+    }
+    const trimmed = editingName.trim();
+    if (!trimmed) {
+      setEditingError(labels.emptyCategoryError);
+      return;
+    }
+    const duplicate = state.categories.find(
+      category => category.name.toLowerCase() === trimmed.toLowerCase() && category.id !== editingCategoryId,
+    );
+    if (duplicate) {
+      dispatch(mergeCategories(editingCategoryId, duplicate.id));
+      announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', duplicate.name));
+    } else {
+      dispatch(renameCategory(editingCategoryId, trimmed));
+      announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', trimmed));
+    }
+    cancelRename();
+  }, [announce, cancelRename, dispatch, editingCategoryId, editingName, labels.dropOnCategoryAnnouncement, labels.emptyCategoryError, state.categories]);
+
+  /**
+   * Handles key interactions within the rename input.
+   */
+  const handleRenameKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        commitRename();
+      }
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelRename();
+      }
+    },
+    [cancelRename, commitRename],
+  );
+
+  /**
+   * Updates the inline rename input for the provided category and clears validation state.
+   *
+   * @param categoryId - Identifier for the category whose name is being edited.
+   * @param value - Latest text entered by the user.
+   */
+  const handleRenameChange = useCallback(
+    (categoryId: string, value: string) => {
+      if (editingCategoryId !== categoryId) {
+        setEditingCategoryId(categoryId);
+      }
+      setEditingName(value);
+      setEditingError(null);
+    },
+    [editingCategoryId],
+  );
+
+  /**
+   * Removes a category and reassigns its features to the uncategorized bucket.
+   */
+  const handleDeleteCategory = useCallback(
+    (categoryId: string) => {
+      dispatch(deleteCategory(categoryId));
+      announce(labels.uncategorizedAnnouncement);
+    },
+    [announce, dispatch, labels.uncategorizedAnnouncement],
+  );
+
+  /**
+   * Internal helper for keyboard-based feature reordering.
+   */
+  const moveFeatureByOffset = useCallback(
+    (featureId: string, direction: -1 | 1) => {
+      const bucketIndex = layoutBuckets.findIndex(bucket =>
+        bucket.features.some(feature => feature.id === featureId),
+      );
+      if (bucketIndex === -1) {
+        return;
+      }
+      const bucket = layoutBuckets[bucketIndex];
+      const featureIndex = bucket.features.findIndex(feature => feature.id === featureId);
+      if (featureIndex === -1) {
+        return;
+      }
+
+      const repositionWithinBucket = (index: number, neighbour?: { name: string }) => {
+        dispatch(moveFeature(featureId, bucket.categoryId, index));
+        if (neighbour) {
+          announce(labels.dropBetweenFeaturesAnnouncement.replace('{featureName}', neighbour.name));
+        }
+      };
+
+      if (direction === -1) {
+        if (featureIndex > 0) {
+          repositionWithinBucket(featureIndex - 1, bucket.features[featureIndex - 1]);
+          return;
+        }
+        if (bucketIndex > 0) {
+          const previousBucket = layoutBuckets[bucketIndex - 1];
+          dispatch(moveFeature(featureId, previousBucket.categoryId, previousBucket.features.length));
+          if (previousBucket.categoryId === null) {
+            announce(labels.uncategorizedAnnouncement);
+          } else if (previousBucket.features.length > 0) {
+            const anchor = previousBucket.features[previousBucket.features.length - 1];
+            announce(labels.dropBetweenFeaturesAnnouncement.replace('{featureName}', anchor.name));
+          } else if (previousBucket.title) {
+            announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', previousBucket.title));
+          }
+        }
+        return;
+      }
+
+      if (featureIndex < bucket.features.length - 1) {
+        repositionWithinBucket(featureIndex + 1, bucket.features[featureIndex + 1]);
+        return;
+      }
+      if (bucketIndex < layoutBuckets.length - 1) {
+        const nextBucket = layoutBuckets[bucketIndex + 1];
+        dispatch(moveFeature(featureId, nextBucket.categoryId, 0));
+        if (nextBucket.categoryId === null) {
+          announce(labels.uncategorizedAnnouncement);
+        } else if (nextBucket.title) {
+          announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', nextBucket.title));
+        }
+      }
+    },
+    [announce, dispatch, labels.dropBetweenFeaturesAnnouncement, labels.dropOnCategoryAnnouncement, labels.uncategorizedAnnouncement, layoutBuckets],
+  );
+
+  /**
+   * Handles keyboard-driven drag toggling for feature items.
+   */
+  const handleFeatureKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, featureId: string) => {
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        const isDragging = draggingItem?.type === 'feature' && draggingItem.id === featureId;
+        setDraggingItem(isDragging ? null : { type: 'feature', id: featureId, viaKeyboard: true });
+        announce(labels.featureGrabAnnouncement);
+        return;
+      }
+      if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && draggingItem?.type === 'feature') {
+        event.preventDefault();
+        moveFeatureByOffset(featureId, event.key === 'ArrowUp' ? -1 : 1);
+      }
+      if (event.key === 'Escape') {
+        resetDragState();
+      }
+    },
+    [announce, draggingItem, labels.featureGrabAnnouncement, moveFeatureByOffset, resetDragState],
+  );
+
+  /**
+   * Keyboard helper for category reordering.
+   */
+  const moveCategoryByOffset = useCallback(
+    (categoryId: string, direction: -1 | 1) => {
+      const ordered = state.categories.slice().sort((a, b) => a.order - b.order);
+      const index = ordered.findIndex(category => category.id === categoryId);
+      if (index === -1) {
+        return;
+      }
+      const nextIndex = Math.max(0, Math.min(index + direction, ordered.length - 1));
+      dispatch(moveCategory(categoryId, nextIndex));
+      const neighbour = ordered[nextIndex];
+      if (neighbour) {
+        announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', neighbour.name));
+      }
+    },
+    [announce, dispatch, labels.dropOnCategoryAnnouncement, state.categories],
+  );
+
+  /**
+   * Handles keyboard events on category headers for drag toggling.
+   */
+  const handleCategoryKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>, categoryId: string) => {
+      if (event.key === ' ' || event.key === 'Enter') {
+        event.preventDefault();
+        const isDragging = draggingItem?.type === 'category' && draggingItem.id === categoryId;
+        setDraggingItem(isDragging ? null : { type: 'category', id: categoryId, viaKeyboard: true });
+        announce(labels.categoryGrabAnnouncement);
+        return;
+      }
+      if ((event.key === 'ArrowUp' || event.key === 'ArrowDown') && draggingItem?.type === 'category') {
+        event.preventDefault();
+        moveCategoryByOffset(categoryId, event.key === 'ArrowUp' ? -1 : 1);
+      }
+      if (event.key === 'Escape') {
+        resetDragState();
+      }
+    },
+    [announce, draggingItem, labels.categoryGrabAnnouncement, moveCategoryByOffset, resetDragState],
+  );
+
+  /**
+   * Dispatches feature moves and announces drop outcomes.
+   */
+  const dropFeature = useCallback(
+    (featureId: string, categoryId: string | null, index: number) => {
+      dispatch(moveFeature(featureId, categoryId, index));
+      if (categoryId === null) {
+        announce(labels.uncategorizedAnnouncement);
+      } else {
+        const category = state.categories.find(item => item.id === categoryId);
+        if (category) {
+          announce(labels.dropOnCategoryAnnouncement.replace('{categoryName}', category.name));
+        }
+      }
+      resetDragState();
+    },
+    [announce, dispatch, labels.dropOnCategoryAnnouncement, labels.uncategorizedAnnouncement, resetDragState, state.categories],
+  );
+
+  /**
+   * Safely parses drag payload metadata.
+   */
+  const parseDragData = useCallback((event: DragEvent) => {
+    try {
+      const data = event.dataTransfer?.getData(DRAG_DATA_MIME);
+      if (!data) {
+        return null;
+      }
+      return JSON.parse(data) as DraggingItem;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  /**
+   * Configures drag payloads for feature items.
+   */
+  const handleFeatureDragStart = useCallback(
+    (event: DragEvent<HTMLButtonElement>, featureId: string) => {
+      event.dataTransfer?.setData(
+        DRAG_DATA_MIME,
+        JSON.stringify({ type: 'feature', id: featureId }),
+      );
+      event.dataTransfer?.setDragImage(event.currentTarget, 0, 0);
+      event.dataTransfer.effectAllowed = 'move';
+      setDraggingItem({ type: 'feature', id: featureId, viaKeyboard: false });
+      announce(labels.featureGrabAnnouncement);
+    },
+    [announce, labels.featureGrabAnnouncement],
+  );
+
+  /**
+   * Configures drag payloads for category headers.
+   */
+  const handleCategoryDragStart = useCallback(
+    (event: DragEvent<HTMLDivElement>, categoryId: string) => {
+      event.dataTransfer?.setData(
+        DRAG_DATA_MIME,
+        JSON.stringify({ type: 'category', id: categoryId }),
+      );
+      event.dataTransfer.effectAllowed = 'move';
+      setDraggingItem({ type: 'category', id: categoryId, viaKeyboard: false });
+      announce(labels.categoryGrabAnnouncement);
+    },
+    [announce, labels.categoryGrabAnnouncement],
+  );
+
+  return {
+    newCategoryName,
+    newCategoryError,
+    editingCategoryId,
+    editingName,
+    editingError,
+    draggingItem,
+    featureDropTarget,
+    categoryDropTarget,
+    handleNewCategoryChange,
+    handleAddCategory,
+    beginRename,
+    commitRename,
+    cancelRename,
+    handleRenameKeyDown,
+    handleRenameChange,
+    handleDeleteCategory,
+    handleFeatureKeyDown,
+    handleCategoryKeyDown,
+    handleFeatureDragStart,
+    handleCategoryDragStart,
+    dropFeature,
+    parseDragData,
+    resetDragState,
+    setFeatureDropTarget,
+    setCategoryDropTarget,
+  };
+};

--- a/tests/Sidebar.test.tsx
+++ b/tests/Sidebar.test.tsx
@@ -1,7 +1,7 @@
 /* @vitest-environment jsdom */
 import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/vitest';
 import { Sidebar } from '../components/layouts/Sidebar';
 import type { Mode } from '../types';
@@ -20,10 +20,8 @@ afterEach(() => {
 });
 
 describe('Sidebar', () => {
-  it('allows collapsing and expanding navigation sections', () => {
-    console.info(
-      'Verifying sidebar sections toggle their mode lists without affecting the surrounding layout.',
-    );
+  it('collapses and expands a category when the sidebar is expanded', () => {
+    console.info('Ensuring expanded sidebar renders categories that can be collapsed.');
 
     render(
       <Sidebar
@@ -34,22 +32,20 @@ describe('Sidebar', () => {
       />,
     );
 
-    const workspaceSection = screen.getByTestId('sidebar-section-workspace');
-    const workspaceList = within(workspaceSection).getByRole('list');
-    expect(workspaceList).toBeVisible();
+    const collapseButton = screen.getByRole('button', { name: /collapse workspace/i });
+    const featureLabel = screen.getByText('Technical Summarizer');
+    expect(featureLabel).toBeVisible();
 
-    const toggleButton = within(workspaceSection).getByRole('button', { name: /workspace/i });
-    fireEvent.click(toggleButton);
-    expect(workspaceList).not.toBeVisible();
+    fireEvent.click(collapseButton);
+    expect(screen.queryByText('Technical Summarizer')).not.toBeInTheDocument();
 
-    fireEvent.click(toggleButton);
-    expect(workspaceList).toBeVisible();
+    const expandButton = screen.getByRole('button', { name: /expand workspace/i });
+    fireEvent.click(expandButton);
+    expect(screen.getByText('Technical Summarizer')).toBeVisible();
   });
 
-  it('uses compact spacing between icons when collapsed', () => {
-    console.info(
-      'Ensuring collapsed sidebar sections drop extra padding so icon-only mode does not leave unintended gaps.',
-    );
+  it('hides category management controls when collapsed', () => {
+    console.info('Verifying collapsed sidebar hides rename/delete affordances and the add button.');
 
     render(
       <Sidebar
@@ -60,10 +56,9 @@ describe('Sidebar', () => {
       />,
     );
 
-    const workspaceSection = screen.getByTestId('sidebar-section-workspace');
-    expect(workspaceSection).toHaveClass('px-1');
-    expect(workspaceSection).toHaveClass('first:pt-2');
-    expect(workspaceSection).not.toHaveClass('py-2');
-    expect(workspaceSection).not.toHaveClass('py-4');
+    expect(screen.queryByLabelText(/rename category/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/delete category/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add a new category/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('textbox')).toBeNull();
   });
 });

--- a/tests/Sidebar.test.tsx
+++ b/tests/Sidebar.test.tsx
@@ -87,6 +87,44 @@ describe('Sidebar', () => {
     expect(screen.getByText('Technical Summarizer')).toBeVisible();
   });
 
+  it('collapses a category when clicking the header body without revealing actions', async () => {
+    console.info('Validating that clicking a category header toggles collapse without exposing inline actions.');
+
+    render(
+      <Sidebar
+        collapsed={false}
+        onToggle={noop}
+        activeMode={'technical' as Mode}
+        onSelectMode={noop}
+      />,
+    );
+
+    await screen.findByTestId('category-section-workspace');
+    const header = document.querySelector('[data-category-id="workspace"]') as HTMLElement;
+    expect(header).toBeTruthy();
+
+    const initialActions = header.querySelector('[data-testid="category-actions-workspace"]') as HTMLElement;
+    expect(initialActions).toHaveAttribute('aria-hidden', 'true');
+
+    fireEvent.click(header);
+
+    await waitFor(() => {
+      expect(screen.queryByText('Technical Summarizer')).not.toBeInTheDocument();
+    });
+
+    const collapsedHeader = document.querySelector('[data-category-id="workspace"]') as HTMLElement;
+    expect(collapsedHeader).toBeTruthy();
+    const collapsedActions = collapsedHeader.querySelector('[data-testid="category-actions-workspace"]') as HTMLElement;
+    expect(collapsedActions).toHaveAttribute('aria-hidden', 'true');
+
+    fireEvent.click(collapsedHeader);
+    await screen.findByText('Technical Summarizer');
+
+    const expandedHeader = document.querySelector('[data-category-id="workspace"]') as HTMLElement;
+    const expandedActions = expandedHeader.querySelector('[data-testid="category-actions-workspace"]') as HTMLElement;
+    expect(expandedActions).toHaveAttribute('aria-hidden', 'true');
+  });
+
   it('hides category management controls when collapsed', () => {
     console.info('Verifying collapsed sidebar hides rename/delete affordances and the add button.');
 

--- a/tests/Sidebar.test.tsx
+++ b/tests/Sidebar.test.tsx
@@ -143,6 +143,23 @@ describe('Sidebar', () => {
     expect(screen.queryByRole('textbox')).toBeNull();
   });
 
+  it('collapses the uncategorized placeholder when no items exist', async () => {
+    console.info('Ensuring the uncategorized drop area stays hidden until features populate it.');
+
+    render(
+      <Sidebar
+        collapsed={false}
+        onToggle={noop}
+        activeMode={'technical' as Mode}
+        onSelectMode={noop}
+      />,
+    );
+
+    const uncategorizedSection = await screen.findByTestId('category-section-uncategorized');
+    expect(uncategorizedSection.children).toHaveLength(1);
+    expect(uncategorizedSection.querySelector('ul')).toBeTruthy();
+  });
+
   it('moves a feature into another category when dropped on the header', async () => {
     console.info('Verifying dropping a feature on a category header reassigns it.');
 

--- a/tests/__mocks__/mui-icons/Handyman.ts
+++ b/tests/__mocks__/mui-icons/Handyman.ts
@@ -1,0 +1,3 @@
+import createMockIcon from './createMockIcon';
+
+export default createMockIcon('HandymanIcon');

--- a/tests/__mocks__/mui-icons/HighlightOff.ts
+++ b/tests/__mocks__/mui-icons/HighlightOff.ts
@@ -1,0 +1,3 @@
+import createMockIcon from './createMockIcon';
+
+export default createMockIcon('HighlightOffIcon');


### PR DESCRIPTION
## Summary
- add the new sidebar organizer module that manages categories, drag/drop, rename, and persistence for sidebar items
- replace the legacy static navigation rendering in `Sidebar` with the modular organizer while supplying the icon registry
- ensure rename state tracks the active category id across organizer components and types

## Testing
- `npm run typecheck` *(fails: repo lacks @mui/icons-material type declarations; pre-existing project issue)*

------
https://chatgpt.com/codex/tasks/task_e_68cfa8d1c3708326a8dab79c3c5ec60c